### PR TITLE
fix: manually summarise datapoints for graphiteWorking check

### DIFF
--- a/test/graphiteworking.spec.js
+++ b/test/graphiteworking.spec.js
@@ -6,7 +6,7 @@ const proxyquire = require('proxyquire').noCallThru().noPreserveCache();
 describe('Graphite Working Check', function(){
 
 	const fixture = require('./fixtures/config/graphiteWorkingFixture').checks[0];
-	
+
 	let GraphiteWorkingCheck;
 	let check;
 	let mockFetch;
@@ -15,10 +15,12 @@ describe('Graphite Working Check', function(){
 		{
 			"target": "summarize(next.fastly.133g5BGAc00Hv4v8t0dMry.asia.requests, \"1h\", \"sum\", true)",
 			"datapoints": [
-				[
-					202,
-					1459333140
-				]
+				[ null, 1459333140 ],
+				[ null, 1459333200 ],
+				[ 1, 1459333260 ],
+				[ 1, 1459333320 ],
+				[ null, 1459333380 ],
+				[ null, 1459333420 ],
 			]
 		}
 	];
@@ -27,10 +29,12 @@ describe('Graphite Working Check', function(){
 		{
 			"target": "summarize(next.fastly.133g5BGAc00Hv4v8t0dMry.anzac.requests, \"1h\", \"sum\", true)",
 			"datapoints": [
-				[
-					null,
-					1459337340
-				]
+				[ null, 1459333140 ],
+				[ null, 1459333200 ],
+				[ null, 1459333260 ],
+				[ null, 1459333320 ],
+				[ null, 1459333380 ],
+				[ null, 1459333420 ],
 			]
 		}
 	];
@@ -46,11 +50,11 @@ describe('Graphite Working Check', function(){
 				return Promise.resolve(response);
 			}
 		}));
-		
+
 		GraphiteWorkingCheck = proxyquire('../src/checks/graphiteWorking.check.js', {'node-fetch':mockFetch})
 		check = new GraphiteWorkingCheck(fixture);
 	}
-	
+
 	it('Should call graphite using the given key', () => {
 		setup(goodResponse);
 		check.start();
@@ -58,12 +62,11 @@ describe('Graphite Working Check', function(){
 			sinon.assert.called(mockFetch);
 			let url = mockFetch.lastCall.args[0];
 			expect(url).to.contain(fixture.key);
-			expect(url).to.contain('from=-1hours');
 			expect(url).to.contain('format=json');
 			expect(url).to.contain('_salt=');
 		});
 	});
-	
+
 	it('Should pass if there is some data for the given key', () => {
 		setup(goodResponse);
 		check.start();
@@ -71,7 +74,7 @@ describe('Graphite Working Check', function(){
 			expect(check.getStatus().ok).to.be.true;
 		});
 	});
-	
+
 	it('Should fail if there is no data', () => {
 		setup(badResponse);
 		check.start();


### PR DESCRIPTION
Using graphite's `summarize` function gives you 2 datapoints, one for the left-most part of the axis
and the other for the right-most. These are averaged out to give a straight line on a graph, but don't
represent accurate values, for example if the latest value is 0 but the rest are high, you won't see
the dropoff using `summarize` until the high data is over the bounds of the average. Conversely, if its
at 0 for a while, and new non-zeo data comes in, again this won't be visible or accurate for a while.

The purpose of this healthcheck is to simply check if the latest entries are non-zero. So we can potentially
just get the latest value in the timeseries and check that... a small problem herein lies that the data
in graphite can be out of sync from real world. From eye balling as much as 7 minute delays before it
starts backfilling data.

Because of this, the function has now been changed to get the last 10 minutes worth of data, sum this up
in JS and getting the grand total number of requests over the last 10 minutes. If _that_ number is 0 then
we have a problem. This means we'll know about failures 10 minutes after they happen. 10 minutes seems
like a long time but it is a trade off between long times knowing about failure vs lots of erroneous false
positives (or negatives?).