### PR TITLE
Allow fetch to be configured for the JSON check.

### DIFF
--- a/src/checks/json.check.js
+++ b/src/checks/json.check.js
@@ -10,6 +10,7 @@ class JsonCheck extends Check{
 		this.callback = options.callback;
 		this.url = options.url;
 		this.checkResultInternal = options.checkResult;
+		this.fetchOptions = options.fetchOptions;
 	}
 
 	get checkOutput(){
@@ -17,7 +18,7 @@ class JsonCheck extends Check{
 	}
 
 	tick(){
-		return fetch(this.url)
+		return fetch(this.url, this.fetchOptions)
 			.then(response => {
 				if(!response.ok){
 					throw new Error('BadResponse ' + response.status);

--- a/test/fixtures/config/jsonCheckFixture.js
+++ b/test/fixtures/config/jsonCheckFixture.js
@@ -19,6 +19,11 @@ module.exports = {
 			interval: '1s',
 			callback: function(json){
 				return json.propertyToCheck;
+			},
+			fetchOptions: {
+			    headers: {
+			        ApiKey: "ApiKey"
+			    }
 			}
 		}
 	]

--- a/test/json.check.spec.js
+++ b/test/json.check.spec.js
@@ -30,7 +30,7 @@ describe('JSON Checker', function(){
 		const check = setup(200, {propertyToCheck:true});
 		check.start();
 		setTimeout(function(){
-			sinon.assert.called(mockFetch);
+			sinon.assert.calledWith(mockFetch, config.url, config.fetchOptions);
 			sinon.assert.called(config.callback);
 			done();
 		});
@@ -40,7 +40,7 @@ describe('JSON Checker', function(){
 		const check = setup(200, {propertyToCheck:true});
 		check.start();
 		setTimeout(function(){
-			sinon.assert.called(mockFetch);
+			sinon.assert.calledWith(mockFetch, config.url, config.fetchOptions);
 			expect(check.getStatus().ok).to.be.true;
 			done();
 		});
@@ -50,7 +50,7 @@ describe('JSON Checker', function(){
 		const check = setup(200, {propertyToCheck:false});
 		check.start();
 		setTimeout(function(){
-			sinon.assert.called(mockFetch);
+			sinon.assert.calledWith(mockFetch, config.url, config.fetchOptions);
 			expect(check.getStatus().ok).to.be.false;
 			done();
 		});


### PR DESCRIPTION
This will allow us to have checks for APIs that require API Keys for their
Good to go endpoints.