### PR TITLE
remove the /signup/api/payment-gateway-params path from signup profile of the service registry fixture as this endpoint is no longer served by the signup app

### DIFF
--- a/test/fixtures/serviceRegistryFixture.json
+++ b/test/fixtures/serviceRegistryFixture.json
@@ -1075,7 +1075,6 @@
       "^/signup",
       "^/signup$",
       "^/signup/api/subscription$",
-      "^/signup/api/payment-gateway-params/[a-zA-z]*/[A-Z]{3}$",
       "^/thank-you$",
       "^/payment-gateway-callback$"
     ],


### PR DESCRIPTION
cc/ @aintgoin2goa 