### PR TITLE
feat(response-text): add response-text check

### DIFF
--- a/src/checks/fetchcheck.js
+++ b/src/checks/fetchcheck.js
@@ -1,0 +1,42 @@
+'use strict';
+const status = require('./status');
+const Check = require('./check');
+const fetch = require('node-fetch');
+
+class FetchCheck extends Check{
+
+	constructor(options){
+		super(options);
+		this.callback = options.callback;
+		this.url = options.url;
+		this.checkResultInternal = options.checkResult;
+		this.fetchOptions = options.fetchOptions;
+	}
+
+	get checkOutput(){
+		return this.checkResultInternal[this.status];
+	}
+
+	_fetch() {
+		return fetch(this.url, this.fetchOptions)
+			.then(response => {
+				if(!response.ok){
+					throw new Error('BadResponse ' + response.status);
+				}
+				return response;
+			})
+	}
+
+	tick(){
+		return this._fetch()
+			.then(response => {
+				this.status = this.callback(response) ? status.PASSED : status.FAILED;
+			})
+			.catch(err => {
+				console.error('Failed to get response', err);
+				this.status = status.FAILED;
+			})
+	}
+}
+
+module.exports = FetchCheck;

--- a/src/checks/json.check.js
+++ b/src/checks/json.check.js
@@ -1,41 +1,12 @@
 'use strict';
-const status = require('./status');
-const Check = require('./check');
-const fetch = require('node-fetch');
+const FetchCheck = require('./fetchcheck');
 
-class JsonCheck extends Check{
+class JsonCheck extends FetchCheck{
 
-	constructor(options){
-		super(options);
-		this.callback = options.callback;
-		this.url = options.url;
-		this.checkResultInternal = options.checkResult;
-		this.fetchOptions = options.fetchOptions;
+	_fetch() {
+		return super._fetch.apply(this, arguments).then((response) => response.json());
 	}
 
-	get checkOutput(){
-		return this.checkResultInternal[this.status];
-	}
-
-	tick(){
-		return fetch(this.url, this.fetchOptions)
-			.then(response => {
-				if(!response.ok){
-					throw new Error('BadResponse ' + response.status);
-				}
-
-				return response.json();
-			})
-			.then(json => {
-				let result = this.callback(json);
-				this.status = result ? status.PASSED : status.FAILED;
-			})
-			.catch(err => {
-				console.error('Failed to get JSON', err);
-				this.status = status.FAILED;
-			})
-	}
 }
 
 module.exports = JsonCheck;
-

--- a/src/checks/string.check.js
+++ b/src/checks/string.check.js
@@ -1,39 +1,28 @@
 'use strict';
 const status = require('./status');
-const Check = require('./check');
+const FetchCheck = require('./fetchcheck');
 const fetch = require('node-fetch');
 
-class StringCheck extends Check {
+class StringCheck extends FetchCheck {
 
 	constructor(options){
 		super(options);
-		this.expected = options.expected;
-		this.url = options.url;
-		this.fetchOptions = options.fetchOptions;
-	}
-
-	get checkOutput(){
-		if(this.status === status.PENDING){
-			return 'this test has not yet run';
-		}
-
-		return `${this.url} is ${this.status === status.PASSED ? '' : 'not'} equal to ${this.expected}`;
-	}
-
-	tick(){
-		return fetch(this.url, this.fetchOptions)
-			.then(response => {
-				if(!response.ok){
-					throw new Error('BadResponse ' + response.status);
+		if (options.expected) {
+				this.callback = (result) => {
+					return result === options.expected;
 				}
-				return response.text()
-			})
-			.then(body => this.status = body === this.expected ? status.PASSED : status.FAILED)
-			.catch(err => {
-				console.error('Response was not OK', err);
-				this.status = status.FAILED;
-			});
+				this.checkResultInternal = this.checkResultInternal || {
+					[status.PENDING]: `this test has not yet run`,
+					[status.PASSED]: `${this.url} is equal to ${this.expected}`,
+					[status.FAILED]: `${this.url} is not equal to ${this.expected}`,
+				}
+		}
 	}
+
+	_fetch() {
+		return super._fetch.apply(this, arguments).then((response) => response.text());
+	}
+
 }
 
 module.exports = StringCheck;

--- a/test/fixtures/config/stringCheckFixture.js
+++ b/test/fixtures/config/stringCheckFixture.js
@@ -23,6 +23,29 @@ module.exports = {
                     ApiKey: "ApiKey"
                 }
             }
+		},
+		{
+			type: 'string',
+			name: 'test2',
+			url: 'http://pretendurl.com',
+			callback(result) {
+				return result === 'OK';
+			},
+			severity: 2,
+			businessImpact: 'blah',
+			technicalSummary: 'god knows',
+			panicGuide: 'Don\'t Panic',
+			checkResult: {
+				PASSED: 'Text if check passed',
+				FAILED: 'Text is check failed',
+				PENDING: 'This check has not yet run'
+			},
+			interval: '1s',
+            fetchOptions: {
+                headers: {
+                    ApiKey: "ApiKey"
+                }
+            }
 		}
 	]
 };

--- a/test/json.check.spec.js
+++ b/test/json.check.spec.js
@@ -16,7 +16,8 @@ describe('JSON Checker', function(){
 			ok: status < 300,
 			json: () => Promise.resolve(body)
 		}));
-		JsonCheck = proxyquire('../src/checks/json.check', {'node-fetch':mockFetch});
+		const FetchCheck = proxyquire('../src/checks/fetchcheck', {'node-fetch':mockFetch});
+		JsonCheck = proxyquire('../src/checks/json.check', {'./fetchcheck':FetchCheck});
 		sinon.spy(config, 'callback');
 		return new JsonCheck(config);
 	}

--- a/test/string.check.spec.js
+++ b/test/string.check.spec.js
@@ -2,7 +2,7 @@
 
 const expect = require('chai').expect;
 const sinon = require('sinon');
-const config = require('./fixtures/config/stringCheckFixture').checks[0];
+const checks = require('./fixtures/config/stringCheckFixture').checks;
 const proxyquire = require('proxyquire').noCallThru().noPreserveCache();
 
 describe('String Checker', function(){
@@ -10,22 +10,23 @@ describe('String Checker', function(){
 	let StringCheck;
 	let mockFetch;
 
-	function setup(status, body){
+	function setup(status, body, fixture){
 		mockFetch = sinon.stub().returns(Promise.resolve({
 			status: 200,
 			ok: status < 300,
 			text: () => Promise.resolve(body)
 		}));
-		StringCheck = proxyquire('../src/checks/string.check', {'node-fetch':mockFetch});
-		return new StringCheck(config);
+		const FetchCheck = proxyquire('../src/checks/fetchcheck', {'node-fetch':mockFetch});
+		StringCheck = proxyquire('../src/checks/string.check', {'./fetchcheck':FetchCheck});
+		return new StringCheck(checks[fixture || 0]);
 	}
 
 	it('Should be ok if the url returns the expected value', function(done){
 		const check = setup(200, 'OK');
 		check.start();
 		setTimeout(function(){
-			sinon.assert.calledWith(mockFetch, config.url);
-			sinon.assert.calledWith(mockFetch, config.url, config.fetchOptions);
+			sinon.assert.calledWith(mockFetch, checks[0].url);
+			sinon.assert.calledWith(mockFetch, checks[0].url, checks[0].fetchOptions);
 			expect(check.getStatus().ok).to.be.true;
 			done();
 		});
@@ -35,8 +36,30 @@ describe('String Checker', function(){
 		const check = setup(200, 'NOT OK');
 		check.start();
 		setTimeout(function(){
-			sinon.assert.calledWith(mockFetch, config.url);
-			sinon.assert.calledWith(mockFetch, config.url, config.fetchOptions);
+			sinon.assert.calledWith(mockFetch, checks[0].url);
+			sinon.assert.calledWith(mockFetch, checks[0].url, checks[0].fetchOptions);
+			expect(check.getStatus().ok).to.be.false;
+			done();
+		});
+	});
+
+	it('Should be ok if the callback returns true', function(done){
+		const check = setup(200, 'OK', 1);
+		check.start();
+		setTimeout(function(){
+			sinon.assert.calledWith(mockFetch, checks[1].url);
+			sinon.assert.calledWith(mockFetch, checks[1].url, checks[1].fetchOptions);
+			expect(check.getStatus().ok).to.be.true;
+			done();
+		});
+	});
+
+	it('Should not be ok if the callback returns false', function(done){
+		const check = setup(200, 'NOT OK', 1);
+		check.start();
+		setTimeout(function(){
+			sinon.assert.calledWith(mockFetch, checks[1].url);
+			sinon.assert.calledWith(mockFetch, checks[1].url, checks[1].fetchOptions);
 			expect(check.getStatus().ok).to.be.false;
 			done();
 		});


### PR DESCRIPTION
This check works similar to the json check, except that it just uses fetch's `text()` method
to parse the body.

This is needed for a check where the response is not JSON.

/cc @wheresrhys @ifyio 
