### PR TITLE
Ensure new cloudWatch checks are exported publically

### DIFF
--- a/src/checks/index.js
+++ b/src/checks/index.js
@@ -8,5 +8,7 @@ module.exports = {
 	pingdom : require('./pingdom.check'),
 	graphiteSpike: require('./graphiteSpike.check'),
 	graphiteThreshold: require('./graphiteThreshold.check'),
-	graphiteWorking: require('./graphiteWorking.check')
+	graphiteWorking: require('./graphiteWorking.check'),
+	cloudWatchAlarm: require('./cloudWatchAlarm.check'),
+	cloudWatchThreshold: require('./cloudWatchThreshold.check')
 };


### PR DESCRIPTION
Seems I forgot to add these in #31 & #32 

ronseal