### PR TITLE
Handle empty series for graphiteThreshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ Compares current and historical graphite metrics to see if there is a spike
 Checks whether the value of a graphite metric has crossed a threshold
 
 * metric: [required] Name of graphite metric to count (may contain wildcards)
-* samplePeriod: [default: '5min'] Length of time to count metrics for a sample of current behaviour
-* threshold: [required] Value to chec the metrics against
+* threshold: [required] Value to check the metrics against
+* samplePeriod: [default: '10min'] Length of time to count metrics for a sample of current behaviour
 * direction: [default: 'above'] Direction on which to trigger the healthcheck;
 	- 'above' = alert if value goes above the threshold
 	- 'below' = alert if value goes below the threshold

--- a/test/graphiteThreshold.check.spec.js
+++ b/test/graphiteThreshold.check.spec.js
@@ -19,7 +19,7 @@ function mockGraphite (results) {
 	mockFetch = sinon.stub().returns(Promise.resolve({
 		status: 200,
 		ok: true,
-		json : () => Promise.resolve([{datapoints: [[results.shift()]]}])
+		json : () => Promise.resolve(results ? [{ datapoints: results.map(result => [result]) }] : [])
 	}));
 
 	Check = proxyquire('../src/checks/graphiteThreshold.check', {'node-fetch':mockFetch});
@@ -35,19 +35,19 @@ describe('Graphite Threshold Check', function(){
 
 
 	it('Should be healthy if not above threshold', function (done) {
-		mockGraphite([10]);
+		mockGraphite();
 		check = new Check(getCheckConfig({
 			threshold: 11
 		}));
 		check.start();
 		setTimeout(() => {
-			expect(mockFetch.firstCall.args[0]).to.contain('from=-10min&target=summarize(averageSeries(metric.200),"10min","avg",true)');
+			expect(mockFetch.firstCall.args[0]).to.contain('from=-10min&target=maximumAbove(metric.200,11)');
 			expect(check.getStatus().ok).to.be.true;
 			done();
 		});
 	});
 
-	it('should be unhealty if below threshold', done => {
+	it('should be unhealty if above threshold', done => {
 		mockGraphite([12]);
 		check = new Check(getCheckConfig({
 			threshold: 11
@@ -60,21 +60,20 @@ describe('Graphite Threshold Check', function(){
 	})
 
 	it('Should be healthy if not below threshold', function (done) {
-
-		mockGraphite([12]);
+		mockGraphite();
 		check = new Check(getCheckConfig({
 			threshold: 11,
 			direction: 'below'
 		}));
 		check.start();
 		setTimeout(() => {
-			expect(mockFetch.firstCall.args[0]).to.contain('from=-10min&target=summarize(averageSeries(metric.200),"10min","avg",true)');
+			expect(mockFetch.firstCall.args[0]).to.contain('from=-10min&target=minimumBelow(metric.200,11)');
 			expect(check.getStatus().ok).to.be.true;
 			done();
 		});
 	});
 
-	it('should be unhealty if above threshold', done => {
+	it('should be unhealty if below threshold', done => {
 		mockGraphite([10]);
 		check = new Check(getCheckConfig({
 			threshold: 11,
@@ -89,13 +88,14 @@ describe('Graphite Threshold Check', function(){
 
 
 	it('Should be possible to configure sample period', function(done){
-		mockGraphite([2, 1]);
+		mockGraphite();
 		check = new Check(getCheckConfig({
+			threshold: 11,
 			samplePeriod: '24h'
 		}));
 		check.start();
 		setTimeout(() => {
-			expect(mockFetch.firstCall.args[0]).to.contain('from=-24h&target=summarize(averageSeries(metric.200),"24h","avg",true)');
+			expect(mockFetch.firstCall.args[0]).to.contain('from=-24h&target=maximumAbove(metric.200,11)');
 			done();
 		});
 	});


### PR DESCRIPTION
Also, change logic so check fails if _any_ metric goes above (or below) the threshold, rather than if the average goes above (or below) - seems to be more in the spirit of what a user would want