### PR TITLE
Amend: Graphite threshold check

### DIFF
--- a/src/checks/graphiteThreshold.check.js
+++ b/src/checks/graphiteThreshold.check.js
@@ -44,13 +44,13 @@ class GraphiteThresholdCheck extends Check {
 			.then(sample => {
 				const datapoints = sample[0].datapoints;
 
-				const filteredDatapoints = datapoints.filter(value => {
+				const invalidDatapoints = datapoints.filter(value => {
 					return this.direction === 'above' ?
-						value[0] <= this.threshold :
-						value[0] >= this.threshold;
+						value[0] && value[0] > this.threshold :
+						value[0] && value[0] < this.threshold;
 				});
 
-				const ok = filteredDatapoints.length;
+				const ok = !invalidDatapoints.length;
 
 				this.status = ok ? status.PASSED : status.FAILED;
 				this.checkOutput = ok ? 'No spike detected in graphite data' : 'Spike detected in graphite data';

--- a/src/checks/graphiteThreshold.check.js
+++ b/src/checks/graphiteThreshold.check.js
@@ -37,12 +37,6 @@ class GraphiteThresholdCheck extends Check {
 		return urlBase + `${functionName}(${metric})`;
 	}
 
-	withinThreshold(value) {
-		return this.direction === 'above' ?
-			value[0] <= this.threshold :
-			value[0] >= this.threshold;
-	}
-
 	tick(){
 
 		return fetch(this.sampleUrl)
@@ -50,7 +44,11 @@ class GraphiteThresholdCheck extends Check {
 			.then(sample => {
 				const datapoints = sample[0].datapoints;
 
-				const filteredDatapoints = datapoints.filter(this.withinThreshold.bind(this));
+				const filteredDatapoints = datapoints.filter(value => {
+					return this.direction === 'above' ?
+						value[0] <= this.threshold :
+						value[0] >= this.threshold;
+				});
 
 				const ok = filteredDatapoints.length;
 

--- a/test/graphiteThreshold.check.spec.js
+++ b/test/graphiteThreshold.check.spec.js
@@ -18,7 +18,7 @@ function mockGraphite (results) {
 	mockFetch = sinon.stub().returns(Promise.resolve({
 		status: 200,
 		ok: true,
-		json : () => Promise.resolve([{datapoints: [[results[0]]]}])
+		json : () => Promise.resolve([{datapoints: results}])
 	}));
 
 	Check = proxyquire('../src/checks/graphiteThreshold.check', {'node-fetch':mockFetch});
@@ -46,8 +46,8 @@ describe('Graphite Threshold Check', function(){
 			});
 		});
 
-		it('Should be healthy if below upper threshold', function (done) {
-			mockGraphite([10]);
+		it('Should be healthy if all datapoints below upper threshold', function (done) {
+			mockGraphite([[9],[10]]);
 			check = new Check(getCheckConfig({
 				threshold: 11
 			}));
@@ -58,8 +58,8 @@ describe('Graphite Threshold Check', function(){
 			});
 		});
 
-		it('Should be healthy if equal to upper threshold', function (done) {
-			mockGraphite([11]);
+		it('Should be healthy if any datapoints are equal to upper threshold', function (done) {
+			mockGraphite([[10],[11]]);
 			check = new Check(getCheckConfig({
 				threshold: 11
 			}));
@@ -70,8 +70,8 @@ describe('Graphite Threshold Check', function(){
 			});
 		});
 
-		it('should be unhealty if above upper threshold', done => {
-			mockGraphite([12]);
+		it('should be unhealthy if any datapoints are above upper threshold', done => {
+			mockGraphite([[10],[12]]);
 			check = new Check(getCheckConfig({
 				threshold: 11
 			}));
@@ -99,8 +99,8 @@ describe('Graphite Threshold Check', function(){
 			});
 		});
 
-		it('Should be healthy if above lower threshold', function (done) {
-			mockGraphite([12]);
+		it('Should be healthy if all datapoints are above lower threshold', function (done) {
+			mockGraphite([[12],[13]]);
 			check = new Check(getCheckConfig({
 				threshold: 11,
 				direction: 'below'
@@ -112,8 +112,21 @@ describe('Graphite Threshold Check', function(){
 			});
 		});
 
-		it('should be unhealty if below lower threshold', done => {
-			mockGraphite([10]);
+		it('Should be healthy if any datapoints are equal to lower threshold', function (done) {
+			mockGraphite([[11],[12]]);
+			check = new Check(getCheckConfig({
+				threshold: 11,
+				direction: 'below'
+			}));
+			check.start();
+			setTimeout(() => {
+				expect(check.getStatus().ok).to.be.true;
+				done();
+			});
+		});
+
+		it('should be unhealthy if any datapoints are below lower threshold', done => {
+			mockGraphite([[10],[12]]);
 			check = new Check(getCheckConfig({
 				threshold: 11,
 				direction: 'below'

--- a/test/graphiteThreshold.check.spec.js
+++ b/test/graphiteThreshold.check.spec.js
@@ -118,7 +118,7 @@ describe('Graphite Threshold Check', function(){
 	});
 
 	it('Should be possible to configure sample period', function(done){
-		mockGraphite([2, 1]);
+		mockGraphite([0]);
 		check = new Check(getCheckConfig({
 			samplePeriod: '24h'
 		}));

--- a/test/graphiteThreshold.check.spec.js
+++ b/test/graphiteThreshold.check.spec.js
@@ -34,6 +34,18 @@ describe('Graphite Threshold Check', function(){
 
 	context('Upper threshold enforced', function () {
 
+		it('Should use maxSeries Graphite function to acquire metrics', function (done) {
+			mockGraphite([0]);
+			check = new Check(getCheckConfig({
+				threshold: 1
+			}));
+			check.start();
+			setTimeout(() => {
+				expect(mockFetch.firstCall.args[0]).to.contain('from=-10min&target=maxSeries(metric.200)');
+				done();
+			});
+		});
+
 		it('Should be healthy if below upper threshold', function (done) {
 			mockGraphite([10]);
 			check = new Check(getCheckConfig({
@@ -41,7 +53,6 @@ describe('Graphite Threshold Check', function(){
 			}));
 			check.start();
 			setTimeout(() => {
-				expect(mockFetch.firstCall.args[0]).to.contain('from=-10min&target=maxSeries(metric.200)');
 				expect(check.getStatus().ok).to.be.true;
 				done();
 			});
@@ -75,22 +86,21 @@ describe('Graphite Threshold Check', function(){
 
 	context('Lower threshold enforced', function () {
 
-		it('Should be healthy if above lower threshold', function (done) {
-			mockGraphite([12]);
+		it('Should use minSeries Graphite function to acquire metrics', function (done) {
+			mockGraphite([0]);
 			check = new Check(getCheckConfig({
-				threshold: 11,
+				threshold: 1,
 				direction: 'below'
 			}));
 			check.start();
 			setTimeout(() => {
 				expect(mockFetch.firstCall.args[0]).to.contain('from=-10min&target=minSeries(metric.200)');
-				expect(check.getStatus().ok).to.be.true;
 				done();
 			});
 		});
 
-		it('Should be healthy if equal to lower threshold', function (done) {
-			mockGraphite([11]);
+		it('Should be healthy if above lower threshold', function (done) {
+			mockGraphite([12]);
 			check = new Check(getCheckConfig({
 				threshold: 11,
 				direction: 'below'

--- a/test/graphiteThreshold.check.spec.js
+++ b/test/graphiteThreshold.check.spec.js
@@ -5,7 +5,6 @@ const fixture = require('./fixtures/config/graphiteThresholdFixture').checks[0];
 const proxyquire = require('proxyquire').noCallThru().noPreserveCache();
 const sinon = require('sinon');
 
-
 function getCheckConfig (conf) {
 	return Object.assign({}, fixture, conf || {});
 }
@@ -19,7 +18,7 @@ function mockGraphite (results) {
 	mockFetch = sinon.stub().returns(Promise.resolve({
 		status: 200,
 		ok: true,
-		json : () => Promise.resolve(results ? [{ datapoints: results.map(result => [result]) }] : [])
+		json : () => Promise.resolve([{datapoints: [[results.shift()]]}])
 	}));
 
 	Check = proxyquire('../src/checks/graphiteThreshold.check', {'node-fetch':mockFetch});
@@ -33,73 +32,101 @@ describe('Graphite Threshold Check', function(){
 		check.stop();
 	});
 
+	context('Upper threshold enforced', function () {
 
-	it('Should be healthy if not above threshold', function (done) {
-		mockGraphite();
-		check = new Check(getCheckConfig({
-			threshold: 11
-		}));
-		check.start();
-		setTimeout(() => {
-			expect(mockFetch.firstCall.args[0]).to.contain('from=-10min&target=maximumAbove(metric.200,11)');
-			expect(check.getStatus().ok).to.be.true;
-			done();
+		it('Should be healthy if below upper threshold', function (done) {
+			mockGraphite([10]);
+			check = new Check(getCheckConfig({
+				threshold: 11
+			}));
+			check.start();
+			setTimeout(() => {
+				expect(mockFetch.firstCall.args[0]).to.contain('from=-10min&target=maxSeries(metric.200)');
+				expect(check.getStatus().ok).to.be.true;
+				done();
+			});
 		});
+
+		it('Should be healthy if equal to upper threshold', function (done) {
+			mockGraphite([11]);
+			check = new Check(getCheckConfig({
+				threshold: 11
+			}));
+			check.start();
+			setTimeout(() => {
+				expect(check.getStatus().ok).to.be.true;
+				done();
+			});
+		});
+
+		it('should be unhealty if above upper threshold', done => {
+			mockGraphite([12]);
+			check = new Check(getCheckConfig({
+				threshold: 11
+			}));
+			check.start();
+			setTimeout(() => {
+				expect(check.getStatus().ok).to.be.false;
+				done();
+			});
+		});
+
 	});
 
-	it('should be unhealty if above threshold', done => {
-		mockGraphite([12]);
-		check = new Check(getCheckConfig({
-			threshold: 11
-		}));
-		check.start();
-		setTimeout(() => {
-			expect(check.getStatus().ok).to.be.false;
-			done();
-		});
-	})
+	context('Lower threshold enforced', function () {
 
-	it('Should be healthy if not below threshold', function (done) {
-		mockGraphite();
-		check = new Check(getCheckConfig({
-			threshold: 11,
-			direction: 'below'
-		}));
-		check.start();
-		setTimeout(() => {
-			expect(mockFetch.firstCall.args[0]).to.contain('from=-10min&target=minimumBelow(metric.200,11)');
-			expect(check.getStatus().ok).to.be.true;
-			done();
+		it('Should be healthy if above lower threshold', function (done) {
+			mockGraphite([12]);
+			check = new Check(getCheckConfig({
+				threshold: 11,
+				direction: 'below'
+			}));
+			check.start();
+			setTimeout(() => {
+				expect(mockFetch.firstCall.args[0]).to.contain('from=-10min&target=minSeries(metric.200)');
+				expect(check.getStatus().ok).to.be.true;
+				done();
+			});
 		});
+
+		it('Should be healthy if equal to lower threshold', function (done) {
+			mockGraphite([11]);
+			check = new Check(getCheckConfig({
+				threshold: 11,
+				direction: 'below'
+			}));
+			check.start();
+			setTimeout(() => {
+				expect(check.getStatus().ok).to.be.true;
+				done();
+			});
+		});
+
+		it('should be unhealty if below lower threshold', done => {
+			mockGraphite([10]);
+			check = new Check(getCheckConfig({
+				threshold: 11,
+				direction: 'below'
+			}));
+			check.start();
+			setTimeout(() => {
+				expect(check.getStatus().ok).to.be.false;
+				done();
+			});
+		});
+
 	});
-
-	it('should be unhealty if below threshold', done => {
-		mockGraphite([10]);
-		check = new Check(getCheckConfig({
-			threshold: 11,
-			direction: 'below'
-		}));
-		check.start();
-		setTimeout(() => {
-			expect(check.getStatus().ok).to.be.false;
-			done();
-		});
-	})
-
 
 	it('Should be possible to configure sample period', function(done){
-		mockGraphite();
+		mockGraphite([2, 1]);
 		check = new Check(getCheckConfig({
-			threshold: 11,
 			samplePeriod: '24h'
 		}));
 		check.start();
 		setTimeout(() => {
-			expect(mockFetch.firstCall.args[0]).to.contain('from=-24h&target=maximumAbove(metric.200,11)');
+			expect(mockFetch.firstCall.args[0]).to.contain('from=-24h&target=maxSeries(metric.200)');
 			done();
 		});
 	});
 
 });
-
-

--- a/test/graphiteThreshold.check.spec.js
+++ b/test/graphiteThreshold.check.spec.js
@@ -35,7 +35,7 @@ describe('Graphite Threshold Check', function(){
 	context('Upper threshold enforced', function () {
 
 		it('Should use maxSeries Graphite function to acquire metrics', function (done) {
-			mockGraphite([0]);
+			mockGraphite([[0]]);
 			check = new Check(getCheckConfig({
 				threshold: 1
 			}));
@@ -87,7 +87,7 @@ describe('Graphite Threshold Check', function(){
 	context('Lower threshold enforced', function () {
 
 		it('Should use minSeries Graphite function to acquire metrics', function (done) {
-			mockGraphite([0]);
+			mockGraphite([[0]]);
 			check = new Check(getCheckConfig({
 				threshold: 1,
 				direction: 'below'
@@ -141,7 +141,7 @@ describe('Graphite Threshold Check', function(){
 	});
 
 	it('Should be possible to configure sample period', function(done){
-		mockGraphite([0]);
+		mockGraphite([[0]]);
 		check = new Check(getCheckConfig({
 			samplePeriod: '24h'
 		}));

--- a/test/graphiteThreshold.check.spec.js
+++ b/test/graphiteThreshold.check.spec.js
@@ -35,7 +35,7 @@ describe('Graphite Threshold Check', function(){
 	context('Upper threshold enforced', function () {
 
 		it('Should use maxSeries Graphite function to acquire metrics', function (done) {
-			mockGraphite([[0]]);
+			mockGraphite([[0, 1234567890]]);
 			check = new Check(getCheckConfig({
 				threshold: 1
 			}));
@@ -47,7 +47,7 @@ describe('Graphite Threshold Check', function(){
 		});
 
 		it('Should be healthy if all datapoints below upper threshold', function (done) {
-			mockGraphite([[9],[10]]);
+			mockGraphite([[9, 1234567890], [10, 1234567891]]);
 			check = new Check(getCheckConfig({
 				threshold: 11
 			}));
@@ -59,7 +59,7 @@ describe('Graphite Threshold Check', function(){
 		});
 
 		it('Should be healthy if any datapoints are equal to upper threshold', function (done) {
-			mockGraphite([[10],[11]]);
+			mockGraphite([[10, 1234567890], [11, 1234567891]]);
 			check = new Check(getCheckConfig({
 				threshold: 11
 			}));
@@ -71,7 +71,7 @@ describe('Graphite Threshold Check', function(){
 		});
 
 		it('should be unhealthy if any datapoints are above upper threshold', done => {
-			mockGraphite([[10],[12]]);
+			mockGraphite([[10, 1234567890], [12, 1234567891]]);
 			check = new Check(getCheckConfig({
 				threshold: 11
 			}));
@@ -87,7 +87,7 @@ describe('Graphite Threshold Check', function(){
 	context('Lower threshold enforced', function () {
 
 		it('Should use minSeries Graphite function to acquire metrics', function (done) {
-			mockGraphite([[0]]);
+			mockGraphite([[0, 1234567890]]);
 			check = new Check(getCheckConfig({
 				threshold: 1,
 				direction: 'below'
@@ -100,7 +100,7 @@ describe('Graphite Threshold Check', function(){
 		});
 
 		it('Should be healthy if all datapoints are above lower threshold', function (done) {
-			mockGraphite([[12],[13]]);
+			mockGraphite([[12, 1234567890], [13, 1234567891]]);
 			check = new Check(getCheckConfig({
 				threshold: 11,
 				direction: 'below'
@@ -113,7 +113,7 @@ describe('Graphite Threshold Check', function(){
 		});
 
 		it('Should be healthy if any datapoints are equal to lower threshold', function (done) {
-			mockGraphite([[11],[12]]);
+			mockGraphite([[11, 1234567890], [12, 1234567891]]);
 			check = new Check(getCheckConfig({
 				threshold: 11,
 				direction: 'below'
@@ -126,7 +126,7 @@ describe('Graphite Threshold Check', function(){
 		});
 
 		it('should be unhealthy if any datapoints are below lower threshold', done => {
-			mockGraphite([[10],[12]]);
+			mockGraphite([[10, 1234567890], [12, 1234567891]]);
 			check = new Check(getCheckConfig({
 				threshold: 11,
 				direction: 'below'
@@ -141,7 +141,7 @@ describe('Graphite Threshold Check', function(){
 	});
 
 	it('Should be possible to configure sample period', function(done){
-		mockGraphite([[0]]);
+		mockGraphite([[0, 1234567890]]);
 		check = new Check(getCheckConfig({
 			samplePeriod: '24h'
 		}));

--- a/test/graphiteThreshold.check.spec.js
+++ b/test/graphiteThreshold.check.spec.js
@@ -18,7 +18,7 @@ function mockGraphite (results) {
 	mockFetch = sinon.stub().returns(Promise.resolve({
 		status: 200,
 		ok: true,
-		json : () => Promise.resolve([{datapoints: [[results.shift()]]}])
+		json : () => Promise.resolve([{datapoints: [[results[0]]]}])
 	}));
 
 	Check = proxyquire('../src/checks/graphiteThreshold.check', {'node-fetch':mockFetch});


### PR DESCRIPTION
cc @ironsidevsquincy 

Transpired that `minimumBelow` was not available in the version of Graphite that we are using and health checks using `direction: 'below'` to set a lower threshold would fail regardless.

Now uses `maxSeries` and `minSeries` (for upper and lower thresholds respectively) then examines a series of data points and if any exceed the threshold then health check will fail.

Null values are disregarded (value has to be non-null and exceeding the threshold):

![null-values](https://cloud.githubusercontent.com/assets/10484515/21098681/4cb36e40-c062-11e6-9b90-997960f782c8.png)