### PR TITLE
Add error logging for the Graphite spike and threshold checks

### DIFF
--- a/src/checks/graphiteSpike.check.js
+++ b/src/checks/graphiteSpike.check.js
@@ -1,10 +1,13 @@
 'use strict';
 
+const logger = require('@financial-times/n-logger').default;
 const status = require('./status');
 const Check = require('./check');
 const fetch = require('node-fetch');
 const fetchres = require('fetchres');
 const ms = require('ms');
+
+const logEventPrefix = 'GRAPHITE_SPIKE_CHECK';
 
 /** Detects spikes/troughs in a given metric compared to baseline historical data */
 
@@ -88,7 +91,7 @@ class GraphiteSpikeCheck extends Check {
 				this.checkOutput = ok ? 'No spike detected in graphite data' : 'Spike detected in graphite data';
 			})
 			.catch(err => {
-				console.error('Failed to get JSON', err);
+				logger.error(`event=${logEventPrefix}_ERROR message=${err.message} stack="${err.stack.replace(/\n/g, '; ')}" url=${this.sampleUrl}`);
 				this.status = status.FAILED;
 				this.checkOutput = 'Graphite spike check failed to fetch data: ' + err.message;
 			});

--- a/src/checks/graphiteThreshold.check.js
+++ b/src/checks/graphiteThreshold.check.js
@@ -1,10 +1,13 @@
 'use strict';
 
+const logger = require('@financial-times/n-logger').default;
 const status = require('./status');
 const Check = require('./check');
 const fetch = require('node-fetch');
 const fetchres = require('fetchres');
 const ms = require('ms');
+
+const logEventPrefix = 'GRAPHITE_THRESHOLD_CHECK';
 
 // Detects when the value of a metric climbs above/below a threshold value
 
@@ -53,7 +56,7 @@ class GraphiteThresholdCheck extends Check {
 				this.checkOutput = failed ? 'Spike detected in graphite data' : 'No spike detected in graphite data';
 			})
 			.catch(err => {
-				console.error('Failed to get JSON', err);
+				logger.error(`event=${logEventPrefix}_ERROR message=${err.message} stack="${err.stack.replace(/\n/g, '; ')}" url=${this.sampleUrl}`);
 				this.status = status.FAILED;
 				this.checkOutput = 'Graphite spike check failed to fetch data: ' + err.message;
 			});

--- a/src/checks/graphiteWorking.check.js
+++ b/src/checks/graphiteWorking.check.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const status = require('./status');
 const Check = require('./check');
 const fetch = require('node-fetch');


### PR DESCRIPTION
Hopefully this will help us to understand better any issues we have with the checks, such as the internal Graphite going down.