### PR TITLE
add some comparison options

### DIFF
--- a/src/checks/responseCompare.check.js
+++ b/src/checks/responseCompare.check.js
@@ -19,6 +19,8 @@ class ResponseCompareCheck extends Check {
 		super(options);
 		this.comparison = options.comparison;
 		this.urls = options.urls;
+		this.headers = options.headers || {};
+		this.normalizeResponse = options.normalizeResponse || (resp => resp);
 	}
 
 	get checkOutput(){
@@ -33,9 +35,9 @@ class ResponseCompareCheck extends Check {
 	}
 
 	tick(){
-		return Promise.all(this.urls.map(url => fetch(url)))
+		return Promise.all(this.urls.map(url => fetch(url, { headers: this.headers })))
 			.then(responses => {
-				return Promise.all(responses.map(r => r.text()));
+				return Promise.all(responses.map(r => r.text().then(this.normalizeResponse)));
 			})
 			.then(responses => {
 				if(this.comparison === ResponseCompareCheck.comparisons.EQUAL){

--- a/test/fixtures/config/responseCompareFixture.js
+++ b/test/fixtures/config/responseCompareFixture.js
@@ -17,6 +17,24 @@ module.exports = {
 			technicalSummary: 'god knows',
 			panicGuide: 'Don\'t Panic',
 			interval: '1s'
+		},
+		{
+			type: 'responseCompare',
+			urls: [
+				'http://url1.com',
+				'http://url2.com'
+			],
+			comparison: 'equal',
+			name: 'response check',
+			severity: 2,
+			businessImpact: 'blah',
+			technicalSummary: 'god knows',
+			panicGuide: 'Don\'t Panic',
+			interval: '1s',
+			headers: {
+				'x-api-key': 'mysecret'
+			},
+			normalizeResponse: resp => resp.replace(/1234/, 'dddd')
 		}
 	]
 };

--- a/test/responseCompare.check.spec.js
+++ b/test/responseCompare.check.spec.js
@@ -3,7 +3,7 @@
 const expect = require('chai').expect;
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru().noPreserveCache();
-const config = require('./fixtures/config/responseCompareFixture').checks[0];
+const config = require('./fixtures/config/responseCompareFixture').checks;
 
 describe('Response Compare Check', function(){
 
@@ -11,7 +11,7 @@ describe('Response Compare Check', function(){
 	let ResponseCompareCheck;
 	let mockFetch;
 
-	function setup (bodies) {
+	function setup (bodies, config) {
 		mockFetch = sinon.stub();
 		bodies.forEach((body, i) => {
 			mockFetch.onCall(i).returns(Promise.resolve({
@@ -27,7 +27,7 @@ describe('Response Compare Check', function(){
 	describe('equal', function(){
 
 		it('Will pass if the 2 responses are the same', function(done){
-			const check = setup(['hip', 'hip']);
+			const check = setup(['hip', 'hip'], config[0]);
 			check.start();
 			setImmediate(function(){
 				sinon.assert.called(mockFetch);
@@ -38,7 +38,29 @@ describe('Response Compare Check', function(){
 		});
 
 		it('Will fail if the 2 responses are different', function(done){
-			const check = setup(['hur', 'rah']);
+			const check = setup(['hur', 'rah'], config[0]);
+			check.start();
+			setImmediate(function(){
+				sinon.assert.called(mockFetch);
+				expect(check.getStatus().ok).to.be.false;
+				check.stop();
+				done();
+			});
+		});
+
+		it('Will pass if the two normalized responses are the same', function(done){
+			const check = setup(['hip 1234', 'hip dddd'], config[1]);
+			check.start();
+			setImmediate(function(){
+				sinon.assert.called(mockFetch);
+				expect(check.getStatus().ok).to.be.true;
+				check.stop();
+				done();
+			});
+		});
+
+		it('Will fail if the two normalized responses are different', function(done){
+			const check = setup(['hip rahh', 'hip dddd'], config[1]);
 			check.start();
 			setImmediate(function(){
 				sinon.assert.called(mockFetch);


### PR DESCRIPTION
1. specify headers (e.g., backend key)
2. function to "normalize" response (e.g., timestamps) before comparison