### PR TITLE
Fix slightly misleading graphite check error

### DIFF
--- a/src/checks/graphiteSpike.check.js
+++ b/src/checks/graphiteSpike.check.js
@@ -29,7 +29,11 @@ class GraphiteSpikeCheck extends Check {
 			throw new Error('You must set FT_GRAPHITE_KEY environment variable');
 		}
 
-		if (!options.numerator || !options.numerator.match(/next\./)) {
+		if (!options.numerator) {
+			throw new Error(`You must pass in a numerator for this check - e.g., "next.heroku.article.*.express.start"`);
+		}
+		
+		if (!/^next\./.test(options.numerator)) {
 			throw new Error(`You must prepend the numerator (${options.numerator}) with "next." - e.g., "heroku.article.*.express.start" needs to be "next.heroku.article.*.express.start"`);
 		}
 

--- a/src/checks/graphiteSpike.check.js
+++ b/src/checks/graphiteSpike.check.js
@@ -28,13 +28,12 @@ class GraphiteSpikeCheck extends Check {
 		if (!this.ftGraphiteKey) {
 			throw new Error('You must set FT_GRAPHITE_KEY environment variable');
 		}
-
 		if (!options.numerator) {
-			throw new Error(`You must pass in a numerator for this check - e.g., "next.heroku.article.*.express.start"`);
+			throw new Error(`You must pass in a numerator for the "${options.name}" check - e.g., "next.heroku.article.*.express.start"`);
 		}
 		
 		if (!/^next\./.test(options.numerator)) {
-			throw new Error(`You must prepend the numerator (${options.numerator}) with "next." - e.g., "heroku.article.*.express.start" needs to be "next.heroku.article.*.express.start"`);
+			throw new Error(`You must prepend the numerator (${options.numerator}) with "next." for the "${options.name}" check - e.g., "heroku.article.*.express.start" needs to be "next.heroku.article.*.express.start"`);
 		}
 
 		this.sampleUrl = this.generateUrl(options.numerator, options.divisor, this.samplePeriod);

--- a/src/checks/graphiteThreshold.check.js
+++ b/src/checks/graphiteThreshold.check.js
@@ -26,7 +26,11 @@ class GraphiteThresholdCheck extends Check {
 			throw new Error('You must set FT_GRAPHITE_KEY environment variable');
 		}
 
-		if (!options.metric || !options.metric.match(/next\./)) {
+		if (!options.metric) {
+			throw new Error(`You must pass in a metric for this check - e.g., "next.heroku.article.*.express.start"`);
+		}
+
+		if (!/^next\./.test(options.metric)) {
 			throw new Error(`You must prepend the metric (${options.metric}) with "next." - e.g., "heroku.article.*.express.start" needs to be "next.heroku.article.*.express.start"`);
 		}
 		this.metric = options.metric;

--- a/src/checks/graphiteThreshold.check.js
+++ b/src/checks/graphiteThreshold.check.js
@@ -25,13 +25,13 @@ class GraphiteThresholdCheck extends Check {
 		if (!this.ftGraphiteKey) {
 			throw new Error('You must set FT_GRAPHITE_KEY environment variable');
 		}
-
+		
 		if (!options.metric) {
-			throw new Error(`You must pass in a metric for this check - e.g., "next.heroku.article.*.express.start"`);
+			throw new Error(`You must pass in a metric for the "${options.name}" check - e.g., "next.heroku.article.*.express.start"`);
 		}
 
 		if (!/^next\./.test(options.metric)) {
-			throw new Error(`You must prepend the metric (${options.metric}) with "next." - e.g., "heroku.article.*.express.start" needs to be "next.heroku.article.*.express.start"`);
+			throw new Error(`You must prepend the metric (${options.metric}) with "next." for the "${options.name}" check - e.g., "heroku.article.*.express.start" needs to be "next.heroku.article.*.express.start"`);
 		}
 		this.metric = options.metric;
 

--- a/src/checks/graphiteWorking.check.js
+++ b/src/checks/graphiteWorking.check.js
@@ -21,16 +21,18 @@ class GraphiteWorkingCheck extends Check {
 			throw new Error('You must set FT_GRAPHITE_KEY environment variable');
 		}
 
-		if (!options.key || !options.key.match(/next\./)) {
+		if (!options.key) {
+			throw new Error(`You must pass in a key for this check - e.g., "next.heroku.article.*.express.start"`);
+		}
+
+		if (!/^next\./.test(options.key)) {
 			throw new Error(`You must prepend the key (${options.key}) with "next." - e.g., "heroku.article.*.express.start" needs to be "next.heroku.article.*.express.start"`);
 		}
 
-		this.checkOutput = "This check has not yet run";
 		const key = options.key;
 		const time = options.time || '-15minutes';
-		if(!key){
-			throw new Error('You must give a key');
-		}
+		
+		this.checkOutput = "This check has not yet run";
 		this.key = key;
 		this.url = encodeURI(`https://graphite-api.ft.com/render/?target=${key}&from=${time}&format=json`);
 	}

--- a/src/checks/graphiteWorking.check.js
+++ b/src/checks/graphiteWorking.check.js
@@ -22,11 +22,11 @@ class GraphiteWorkingCheck extends Check {
 		}
 
 		if (!options.key) {
-			throw new Error(`You must pass in a key for this check - e.g., "next.heroku.article.*.express.start"`);
+			throw new Error(`You must pass in a key for the "${options.name}" check - e.g., "next.heroku.article.*.express.start"`);
 		}
 
 		if (!/^next\./.test(options.key)) {
-			throw new Error(`You must prepend the key (${options.key}) with "next." - e.g., "heroku.article.*.express.start" needs to be "next.heroku.article.*.express.start"`);
+			throw new Error(`You must prepend the key (${options.key}) with "next." for the "${options.name}" check - e.g., "heroku.article.*.express.start" needs to be "next.heroku.article.*.express.start"`);
 		}
 
 		const key = options.key;


### PR DESCRIPTION
Also updated to use `.test` instead of `.match` for testing against the regex and fixed it to make sure `next` was actually _prepended_.