### PR TITLE
Don't explicitly check for 'next' being the first thing in the string

### DIFF
--- a/src/checks/graphiteSpike.check.js
+++ b/src/checks/graphiteSpike.check.js
@@ -32,7 +32,7 @@ class GraphiteSpikeCheck extends Check {
 			throw new Error(`You must pass in a numerator for the "${options.name}" check - e.g., "next.heroku.article.*.express.start"`);
 		}
 		
-		if (!/^next\./.test(options.numerator)) {
+		if (!/next\./.test(options.numerator)) {
 			throw new Error(`You must prepend the numerator (${options.numerator}) with "next." for the "${options.name}" check - e.g., "heroku.article.*.express.start" needs to be "next.heroku.article.*.express.start"`);
 		}
 

--- a/src/checks/graphiteThreshold.check.js
+++ b/src/checks/graphiteThreshold.check.js
@@ -30,7 +30,7 @@ class GraphiteThresholdCheck extends Check {
 			throw new Error(`You must pass in a metric for the "${options.name}" check - e.g., "next.heroku.article.*.express.start"`);
 		}
 
-		if (!/^next\./.test(options.metric)) {
+		if (!/next\./.test(options.metric)) {
 			throw new Error(`You must prepend the metric (${options.metric}) with "next." for the "${options.name}" check - e.g., "heroku.article.*.express.start" needs to be "next.heroku.article.*.express.start"`);
 		}
 		this.metric = options.metric;

--- a/src/checks/graphiteWorking.check.js
+++ b/src/checks/graphiteWorking.check.js
@@ -25,7 +25,7 @@ class GraphiteWorkingCheck extends Check {
 			throw new Error(`You must pass in a key for the "${options.name}" check - e.g., "next.heroku.article.*.express.start"`);
 		}
 
-		if (!/^next\./.test(options.key)) {
+		if (!/next\./.test(options.key)) {
 			throw new Error(`You must prepend the key (${options.key}) with "next." for the "${options.name}" check - e.g., "heroku.article.*.express.start" needs to be "next.heroku.article.*.express.start"`);
 		}
 


### PR DESCRIPTION
Some checks have them formatted as queries starting like this: `sumSeries(next.heroku.etc)`