### PR TITLE
Keen health checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /node_modules/
 
 /npm-debug.log
+package-lock.json

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ node_modules/@financial-times/n-gage/index.mk:
 .PHONY: test
 
 test-unit:
-	FT_GRAPHITE_KEY=123 HEROKU_AUTH_TOKEN=token mocha
+	KEEN_READ_KEY=123 KEEN_PROJECT_ID=abc FT_GRAPHITE_KEY=123 HEROKU_AUTH_TOKEN=token mocha
 
 test-int:
 	mocha int-tests/ -r loadvars.js

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ To Add more health checks create a new file in the `config` directory.  It shoul
 * name, severity, businessImpact, technicalSummary and panicGuide are all required. See the [specification](https://docs.google.com/document/edit?id=1ftlkDj1SUXvKvKJGvoMoF1GnSUInCNPnNGomqTpJaFk) for details
 * interval: time between checks in milliseconds or any string compatible with [ms](https://www.npmjs.com/package/ms) [default: 1minute]
 * type: The type of check (see below)
+* officeHoursOnly: [default: false] For queries that will probably fail out of hours (e.g. Internet Explorer usage, B2B stuff), set this to true and the check will pass on weekends and outside office hours. Use sparingly.
 
 ## Healthcheck types and options
 
@@ -91,3 +92,17 @@ _Note: this assumes that `AWS_ACCESS_KEY` & `AWS_SECRET_ACCESS_KEY` are implictl
 
 * cloudWatchRegion = [default 'eu-west-1'] AWS region the metrics are stored
 * cloudWatchAlarmName = [required] Name of the CloudWatch alarm to check
+
+### keenThreshold
+Checks whether the result of a keen query for a metric has crossed a threshold
+
+_Note: this assumes that `KEEN_READ_KEY` & `KEEN_PROJECT_ID` are implicitly available as environment variables on process.env_
+
+* query: [required] Query to run to get a count, in the format of [keen-query](https://github.com/Financial-Times/keen-query).
+* threshold: [required] Value to check the metric against
+* timeframe: [default: 'this_60_minutes'] timeframe to run keen query against.
+* direction: [default: 'below'] Direction on which to trigger the healthcheck;
+	- 'above' = alert if value goes above the threshold
+	- 'below' = alert if value goes below the threshold
+
+_Warning_: Keen sometimes has a lag before ingesting, particularly during high traffic periods. It's recommended to have a minimum timeframe of 60 minutes, if not more.

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@financial-times/n-raven": "^2.1.0",
     "aws-sdk": "^2.6.10",
     "fetchres": "^1.5.1",
+    "keen-query": "^3.2.7",
     "moment": "^2.15.1",
     "ms": "^2.0.0",
     "node-fetch": "^1.5.1"

--- a/src/checks/index.js
+++ b/src/checks/index.js
@@ -10,5 +10,6 @@ module.exports = {
 	graphiteThreshold: require('./graphiteThreshold.check'),
 	graphiteWorking: require('./graphiteWorking.check'),
 	cloudWatchAlarm: require('./cloudWatchAlarm.check'),
-	cloudWatchThreshold: require('./cloudWatchThreshold.check')
+	cloudWatchThreshold: require('./cloudWatchThreshold.check'),
+	keenThreshold: require('./keenThreshold.check')
 };

--- a/src/checks/keenThreshold.check.js
+++ b/src/checks/keenThreshold.check.js
@@ -37,6 +37,8 @@ class KeenThresholdCheck extends Check {
 
 
 		this.query = options.query;
+		//Default to 10 minute interval for keen checks so we don't overwhelm it
+		this.interval = options.interval || 10 * 60 * 1000;
 
 		this.checkOutput = 'Keen threshold check has not yet run';
 	}

--- a/src/checks/keenThreshold.check.js
+++ b/src/checks/keenThreshold.check.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const logger = require('@financial-times/n-logger').default;
+const status = require('./status');
+const Check = require('./check');
+const KeenQuery = require('keen-query');
+const ms = require('ms');
+
+const logEventPrefix = 'KEEN_THRESHOLD_CHECK';
+
+// Detects when the value of a metric climbs above/below a threshold value
+
+class KeenThresholdCheck extends Check {
+
+	constructor(options){
+
+		super(options);
+		this.threshold = options.threshold;
+		this.direction = options.direction || 'below';
+
+		this.timeframe = options.timeframe || 'this_60_minutes';
+
+		this.keenProjectId = process.env.KEEN_PROJECT_ID;
+		this.keenReadKey = process.env.KEEN_READ_KEY;
+		if (!(this.keenProjectId && this.keenReadKey)) {
+			throw new Error('You must set KEEN_PROJECT_ID and KEEN_READ_KEY environment variables');
+		}
+
+		KeenQuery.setConfig({
+			KEEN_PROJECT_ID: this.keenProjectId,
+			KEEN_READ_KEY: this.keenReadKey,
+			KEEN_HOST: 'https://keen-proxy.ft.com/3.0'
+		});
+
+		if (!options.query) {
+			throw new Error(`You must pass in a query for the "${options.name}" check - e.g., "page:view->filter(context.app=article)->count()"`);
+		}
+
+
+		this.query = options.query;
+
+		this.checkOutput = 'Keen threshold check has not yet run';
+	}
+
+	tick() {
+
+		return KeenQuery.build(this.query)
+			.filter('user.subscriptions.isStaff!=true')
+			.filter('user.geo.isFinancialTimesOffice!=true')
+			.filter('device.isRobot!=true')
+			.relTime(this.timeframe)
+			.print()
+			.then(result => {
+				if(result && result.rows) {
+					let data = Number(result.rows[0][1]);
+					let failed = this.direction === 'above' ?
+						data && data > this.threshold :
+						data && data < this.threshold;
+						this.status = failed ? status.FAILED : status.PASSED;
+						this.checkOutput = `Got ${data} ${this.timeframe.split('_').join(' ').replace('this', 'in the last')}, which is ${this.direction} the threshold of ${this.threshold}
+
+			${this.query}
+						`;
+				}
+			})
+			.catch(err => {
+				logger.error({ event: `${logEventPrefix}_ERROR`, url: this.query }, err);
+				this.status = status.FAILED;
+				this.checkOutput = 'Keen threshold check failed to fetch data: ' + err.message;
+			});
+	}
+
+}
+
+module.exports = KeenThresholdCheck;

--- a/src/checks/keenThreshold.check.js
+++ b/src/checks/keenThreshold.check.js
@@ -13,7 +13,6 @@ const logEventPrefix = 'KEEN_THRESHOLD_CHECK';
 class KeenThresholdCheck extends Check {
 
 	constructor(options){
-
 		super(options);
 		this.threshold = options.threshold;
 		this.direction = options.direction || 'below';
@@ -43,7 +42,6 @@ class KeenThresholdCheck extends Check {
 	}
 
 	tick() {
-
 		return KeenQuery.build(this.query)
 			.filter('user.subscriptions.isStaff!=true')
 			.filter('user.geo.isFinancialTimesOffice!=true')
@@ -57,7 +55,7 @@ class KeenThresholdCheck extends Check {
 						data && data > this.threshold :
 						data && data < this.threshold;
 						this.status = failed ? status.FAILED : status.PASSED;
-						this.checkOutput = `Got ${data} ${this.timeframe.split('_').join(' ').replace('this', 'in the last')}, which is ${this.direction} the threshold of ${this.threshold}
+						this.checkOutput = `Got ${data} ${this.timeframe.split('_').join(' ').replace('this', 'in the last')}, expected not to be ${this.direction} the threshold of ${this.threshold}
 
 			${this.query}
 						`;

--- a/test/fixtures/config/keenThresholdFixture.js
+++ b/test/fixtures/config/keenThresholdFixture.js
@@ -1,0 +1,17 @@
+'use strict';
+module.exports = {
+	name: 'keen',
+	descriptions : '',
+	checks : [
+		{
+			type: 'keenThreshold',
+			query: 'page:view->count()',
+			name: 'Some keen value is above some threshold',
+			severity: 2,
+			threshold: 4,
+			businessImpact: 'catastrophic',
+			technicalSummary: 'god knows',
+			panicGuide: 'Don\'t Panic'
+		}
+	]
+};

--- a/test/keenThreshold.check.spec.js
+++ b/test/keenThreshold.check.spec.js
@@ -1,0 +1,146 @@
+'use strict';
+
+const expect = require('chai').expect;
+const fixture = require('./fixtures/config/keenThresholdFixture').checks[0];
+const proxyquire = require('proxyquire').noCallThru().noPreserveCache();
+const sinon = require('sinon');
+
+function getCheckConfig (conf) {
+	return Object.assign({}, fixture, conf || {});
+}
+
+let mockKeenQuery;
+let Check;
+
+
+// Mocks a pair of calls to keen for sample and baseline data
+function mockKeen (results) {
+
+	mockKeenQuery = {
+		setConfig: sinon.stub(),
+		build: sinon.stub().returnsThis(),
+		filter: sinon.stub().returnsThis(),
+		relTime: sinon.stub().returnsThis(),
+		print: sinon.stub().returns(Promise.resolve(results))
+	};
+
+	Check = proxyquire('../src/checks/keenThreshold.check', {'keen-query': mockKeenQuery});
+}
+
+describe('Keen Threshold Check', function(){
+
+	let check;
+
+	afterEach(function(){
+		check.stop();
+	});
+
+	context('Upper threshold enforced', function () {
+
+		it('Should be healthy if result above upper threshold', function (done) {
+			mockKeen({
+				rows: [
+					['something', 100]
+				]
+			});
+			check = new Check(getCheckConfig({
+				threshold: 11
+			}));
+			check.start();
+			setTimeout(() => {
+
+				expect(mockKeenQuery.build.firstCall.args[0]).to.contain('page:view->count()');
+				expect(mockKeenQuery.relTime.firstCall.args[0]).to.contain('this_60_minutes');
+				expect(check.getStatus().ok).to.be.true;
+				done();
+			});
+		});
+
+
+		it('should be unhealthy if result is below upper threshold', done => {
+			mockKeen({
+				rows: [
+					['something', 10]
+				]
+			});
+			check = new Check(getCheckConfig({
+				threshold: 11
+			}));
+			check.start();
+			setTimeout(() => {
+				expect(check.getStatus().ok).to.be.false;
+				done();
+			});
+		});
+
+	});
+
+	context('Lower threshold enforced', function () {
+
+		it('Should be healthy if all datapoints are above lower threshold', function (done) {
+			mockKeen({
+				rows: [
+					['something', 10]
+				]
+			});
+			check = new Check(getCheckConfig({
+				threshold: 5,
+				direction: 'below'
+			}));
+			check.start();
+			setTimeout(() => {
+				expect(check.getStatus().ok).to.be.true;
+				done();
+			});
+		});
+
+		it('Should be healthy if any datapoints are equal to lower threshold', function (done) {
+			mockKeen({
+				rows: [
+					['something', 10]
+				]
+			});
+			check = new Check(getCheckConfig({
+				threshold: 10,
+				direction: 'below'
+			}));
+			check.start();
+			setTimeout(() => {
+				expect(check.getStatus().ok).to.be.true;
+				done();
+			});
+		});
+
+		it('should be unhealthy if any datapoints are below lower threshold', done => {
+			mockKeen({
+				rows: [
+					['something', 5]
+				]
+			});
+			check = new Check(getCheckConfig({
+				threshold: 10,
+				direction: 'below'
+			}));
+			check.start();
+			setTimeout(() => {
+				expect(check.getStatus().ok).to.be.false;
+				done();
+			});
+		});
+
+	});
+
+	it('Should be possible to configure sample period', function(done){
+		mockKeen();
+		check = new Check(getCheckConfig({
+			timeframe: 'this_2_days'
+		}));
+		check.start();
+		setTimeout(() => {
+			expect(mockKeenQuery.build.firstCall.args[0]).to.contain('page:view->count()');
+			expect(mockKeenQuery.relTime.firstCall.args[0]).to.contain('this_2_days');
+			done();
+		});
+	});
+
+});


### PR DESCRIPTION
This will allow us to take the healthcheck stuff outside of beacon, and into the apps where it is most relevant.

Warning: Think about what threshold/timeframe to use to avoid a noisy check. Often to check something is working, it's fine to check it's happened once or twice.
 
* Create a new type of healthcheck for keen queries
* Add an 'officeHoursOnly' property of checks, which always returns green outside of office hours. This is useful for some keen queries (e.g. b2b or IE usage based), and @geek-caroline has some use for it in Conversion land.