### PR TITLE
Custom TTL for keen healthchecks

### DIFF
--- a/src/checks/keenThreshold.check.js
+++ b/src/checks/keenThreshold.check.js
@@ -28,7 +28,12 @@ class KeenThresholdCheck extends Check {
 		KeenQuery.setConfig({
 			KEEN_PROJECT_ID: this.keenProjectId,
 			KEEN_READ_KEY: this.keenReadKey,
-			KEEN_HOST: 'https://keen-proxy.ft.com/3.0'
+			KEEN_HOST: 'https://keen-proxy.ft.com/3.0',
+			fetchOptions: {
+				headers: {
+					'Cache-Strategy': 'max-age=5m, stale-while-revalidate=1m'
+				}
+			}
 		});
 
 		if (!options.query) {


### PR DESCRIPTION
 🐿 v2.7.0

Keen proxy has some [clever TTL setting](https://github.com/Financial-Times/keen-proxy/blob/master/vcl/main.vcl#L54) based on the query. Because we're not setting any intervals, I _think_ it defaults to 30mins, which obviously isn't great for a healthcheck!

Force it to be 5 mins.

