### PR TITLE
Defaut Keen to passed

### DIFF
--- a/src/checks/keenThreshold.check.js
+++ b/src/checks/keenThreshold.check.js
@@ -45,6 +45,7 @@ class KeenThresholdCheck extends Check {
 		//Default to 10 minute interval for keen checks so we don't overwhelm it
 		this.interval = options.interval || 10 * 60 * 1000;
 
+		this.status = status.PASSED;
 		this.checkOutput = 'Keen threshold check has not yet run';
 	}
 


### PR DESCRIPTION
Until the first run, the check should be OK.

This is because it could be failing for 10 minutes until it's run, causing it to alert in all the various places.

Example below of the current setup alerting after a dyno restart.

![image](https://user-images.githubusercontent.com/51677/36298624-aef13996-1301-11e8-9a9d-ed0e6b70ef6a.png)
