### PR TITLE
Update keen threshold interval

### DIFF
--- a/src/checks/keenSpike.check.js
+++ b/src/checks/keenSpike.check.js
@@ -40,8 +40,8 @@ class KeenSpikeCheck extends Check {
 		}
 
 		this.query = options.query;
-		//Default to 10 minute interval for keen checks so we don't overwhelm it
-		this.interval = options.interval || 10 * 60 * 1000;
+		//Default to 1 hour interval for keen checks so we don't overwhelm it
+		this.interval = options.interval || 60 * 60 * 1000;
 
 		this.status = status.PASSED;
 		this.checkOutput = 'Keen threshold check has not yet run';

--- a/src/checks/keenThreshold.check.js
+++ b/src/checks/keenThreshold.check.js
@@ -42,8 +42,8 @@ class KeenThresholdCheck extends Check {
 
 
 		this.query = options.query;
-		//Default to 10 minute interval for keen checks so we don't overwhelm it
-		this.interval = options.interval || 10 * 60 * 1000;
+		//Default to 1 hour interval for keen checks so we don't overwhelm it
+		this.interval = options.interval || 60 * 60 * 1000;
 
 		this.status = status.PASSED;
 		this.checkOutput = 'Keen threshold check has not yet run';


### PR DESCRIPTION
In an attempt to reduce the cost of Keen, reduce the default interval that the healthchecks run at to 1 hour.