### PR TITLE
Update graphiteThreshold.check.js

### DIFF
--- a/src/checks/graphiteThreshold.check.js
+++ b/src/checks/graphiteThreshold.check.js
@@ -53,7 +53,7 @@ class GraphiteThresholdCheck extends Check {
 					return result.datapoints.some(value => {
 						return this.direction === 'above' ?
 							value[0] && value[0] > this.threshold :
-							value[0] && value[0] < this.threshold;
+							Number(value[0]) < this.threshold;
 					});
 				});
 

--- a/src/checks/graphiteThreshold.check.js
+++ b/src/checks/graphiteThreshold.check.js
@@ -52,7 +52,7 @@ class GraphiteThresholdCheck extends Check {
 				const failed = sample.some(result => {
 					return result.datapoints.some(value => {
 						return this.direction === 'above' ?
-							value[0] && value[0] > this.threshold :
+							Number(value[0]) > this.threshold :
 							Number(value[0]) < this.threshold;
 					});
 				});


### PR DESCRIPTION
Graphite returns null if no records have been found, meaning when we turned off our subscription metrics, the resulting count was null instead of 0 which for meant our `below 1 / 30m` healthcheck didn't go off as expected because null isn't truthy