### PR TITLE
deal with nulls in metric data

### DIFF
--- a/test/fixtures/config/graphiteWorkingFixture.js
+++ b/test/fixtures/config/graphiteWorkingFixture.js
@@ -1,4 +1,3 @@
-'use strict';
 module.exports = {
 	name: 'graphite check fixture',
 	description: '',
@@ -6,12 +5,9 @@ module.exports = {
 		{
 			type: 'graphiteWorking',
 			name: 'test1',
-			key: 'next.fastly.f8585BOxnGQDMbnkJoM1e.all.requests',
+			metric: 'next.fastly.f8585BOxnGQDMbnkJoM1e.all.requests',
 			severity: 2,
-			businessImpact: 'blah',
-			technicalSummary: 'god knows',
-			panicGuide: 'Don\'t Panic',
-			interval: '1s'
+			businessImpact: 'loss of millions in pounds'
 		}
 	]
 };

--- a/test/graphiteThreshold.check.spec.js
+++ b/test/graphiteThreshold.check.spec.js
@@ -128,7 +128,7 @@ describe('Graphite Threshold Check', function(){
 			check.start();
 			setTimeout(() => {
 				expect(check.getStatus().ok).to.be.false;
-				expect(check.getStatus().checkOutput).to.equal('In the last 10min, the following metric(s) have moved below the threshold value of 11: \tnext.heroku.cpu.min\tnext.heroku.disk.min');
+				expect(check.getStatus().checkOutput).to.equal('In the last 10min, the following metric(s) have moved below the threshold value of 11: next.heroku.cpu.min next.heroku.disk.min');
 				done();
 			});
 		});

--- a/test/graphiteworking.spec.js
+++ b/test/graphiteworking.spec.js
@@ -30,8 +30,8 @@ describe('Graphite Working Check', function(){
 			"target": "summarize(next.fastly.133g5BGAc00Hv4v8t0dMry.anzac.requests, \"1h\", \"sum\", true)",
 			"datapoints": [
 				[ null, 1459333140 ],
-				[ null, 1459333200 ],
-				[ null, 1459333260 ],
+				[ 1, 1459333200 ],
+				[ 1, 1459333260 ],
 				[ null, 1459333320 ],
 				[ null, 1459333380 ],
 				[ null, 1459333420 ],
@@ -61,7 +61,7 @@ describe('Graphite Working Check', function(){
 		return waitFor(10).then(() => {
 			sinon.assert.called(mockFetch);
 			let url = mockFetch.lastCall.args[0];
-			expect(url).to.contain(fixture.key);
+			expect(url).to.contain(fixture.metric);
 			expect(url).to.contain('format=json');
 		});
 	});
@@ -70,6 +70,7 @@ describe('Graphite Working Check', function(){
 		setup(goodResponse);
 		check.start();
 		return waitFor(10).then(() => {
+			expect(check.getStatus().checkOutput).to.equal('next.fastly.f8585BOxnGQDMbnkJoM1e.all.requests has data');
 			expect(check.getStatus().ok).to.be.true;
 		});
 	});
@@ -79,6 +80,7 @@ describe('Graphite Working Check', function(){
 		check.start();
 		return waitFor(10).then(() => {
 			expect(check.getStatus().ok).to.be.false;
+			expect(check.getStatus().checkOutput).to.equal('summarize(next.fastly.133g5BGAc00Hv4v8t0dMry.anzac.requests, "1h", "sum", true) has been null for 3 minutes.');
 		});
 	});
 
@@ -94,7 +96,6 @@ describe('Graphite Working Check', function(){
 		it('Can actually call graphite', () => {
 			check.start();
 			return waitFor(1000).then(() => {
-				console.log(check.getStatus());
 				expect(check.getStatus().ok).to.be.true;
 			});
 		});


### PR DESCRIPTION
- get graphiteThreshold to ignore nulls

- add comments to encourage the use of graphiteWorking for nulls

- refactor graphiteWorking to better deal with wildcarded metrics and to
fail when the last three consecutive datapoints are nulls