### PR TITLE
Adding back override to graphiteWorking

### DIFF
--- a/src/checks/graphiteWorking.check.js
+++ b/src/checks/graphiteWorking.check.js
@@ -29,7 +29,7 @@ class GraphiteWorkingCheck extends Check {
 			throw new Error(`You must pass in a metric for the "${options.name}" check - e.g., "next.heroku.article.*.express.start"`);
 		}
 
-		const fromTime = '-5minutes';
+		const fromTime = options.time || '-15minutes';
 		this.url = encodeURI(`https://graphite-api.ft.com/render/?target=${this.metric}&from=${fromTime}&format=json`);
 
 		this.checkOutput = "This check has not yet run";

--- a/src/checks/graphiteWorking.check.js
+++ b/src/checks/graphiteWorking.check.js
@@ -29,7 +29,7 @@ class GraphiteWorkingCheck extends Check {
 			throw new Error(`You must pass in a metric for the "${options.name}" check - e.g., "next.heroku.article.*.express.start"`);
 		}
 
-		const fromTime = options.time || '-15minutes';
+		const fromTime = options.time || '-5minutes';
 		this.url = encodeURI(`https://graphite-api.ft.com/render/?target=${this.metric}&from=${fromTime}&format=json`);
 
 		this.checkOutput = "This check has not yet run";


### PR DESCRIPTION
This check originally had a time option that could be passed in and default of 15 mins. Reinstating these to ensure consistent functionality.

This is where it was changed - https://github.com/Financial-Times/n-health/pull/93/files#diff-da2131d47c111725f59bb95bb91be19eR32