### PR TITLE
When graphite fetch fails, don't fail the healthcheck

### DIFF
--- a/src/checks/graphiteSpike.check.js
+++ b/src/checks/graphiteSpike.check.js
@@ -95,7 +95,8 @@ class GraphiteSpikeCheck extends Check {
 			})
 			.catch(err => {
 				logger.error({ event: `${logEventPrefix}_ERROR`, url: this.sampleUrl }, err);
-				this.status = status.FAILED;
+				this.status = status.ERRORED;
+				this.severity = 3;
 				this.checkOutput = 'Graphite spike check failed to fetch data: ' + err.message;
 			});
 	}

--- a/src/checks/graphiteThreshold.check.js
+++ b/src/checks/graphiteThreshold.check.js
@@ -76,7 +76,8 @@ class GraphiteThresholdCheck extends Check {
 			})
 			.catch(err => {
 				logger.error({ event: `${logEventPrefix}_ERROR`, url: this.sampleUrl }, err);
-				this.status = status.FAILED;
+				this.severity = 3;
+				this.status = status.ERRORED;
 				this.checkOutput = 'Graphite threshold check failed to fetch data: ' + err.message;
 			});
 	}


### PR DESCRIPTION
 🐿 v2.10.3

We seem to get [regular first byte timeouts](https://financialtimes.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dheroku%20event%3DGRAPHITE_SPIKE_CHECK_ERROR&sid=1542380434.6516153&display.page.search.mode=smart&dispatch.sample_ratio=1&earliest=-1h&latest=now
) from graphite - 

This currently fails the healthcheck, which is both inaccurate and (if the check is sev2+) annoying as we'd get flappy alerts.

In this PR I reduce the severity to 3, and change the status to "Errored" (I'm not actually what that does or if it's valid?)

Arguably it could be set to pending or even okay?
