### PR TITLE
Show spike data in error message

### DIFF
--- a/src/checks/graphiteSpike.check.js
+++ b/src/checks/graphiteSpike.check.js
@@ -90,7 +90,7 @@ class GraphiteSpikeCheck extends Check {
 			 	this.checkOutput = 'No spike detected in graphite data';
 			} else {
 				this.status = status.FAILED;
-				this.checkOutput = `Spike detected in graphite data. Amount: ${data.sample / data.sample} Threshold: ${this.threshold} `;		    
+				this.checkOutput = `Spike detected in graphite data. Sample: ${data.sample} Baseline: ${data.baseline} Threshold: ${this.threshold}`;
 			}
 
 		} catch(err) {

--- a/src/checks/graphiteSpike.check.js
+++ b/src/checks/graphiteSpike.check.js
@@ -85,10 +85,11 @@ class GraphiteSpikeCheck extends Check {
 				? data.sample / data.baseline < this.threshold
 				: data.sample / data.baseline > 1 / this.threshold;
 
-			this.status = ok ? status.PASSED : status.FAILED;
 			if (ok) {
-				this.checkOutput 'No spike detected in graphite data';
+				this.status = status.PASSED;
+			 	this.checkOutput = 'No spike detected in graphite data';
 			} else {
+				this.status = status.FAILED;
 				this.checkOutput = `Spike detected in graphite data. Amount: ${data.sample / data.sample} Threshold: ${this.threshold} `;		    
 			}
 

--- a/src/checks/graphiteSpike.check.js
+++ b/src/checks/graphiteSpike.check.js
@@ -86,7 +86,11 @@ class GraphiteSpikeCheck extends Check {
 				: data.sample / data.baseline > 1 / this.threshold;
 
 			this.status = ok ? status.PASSED : status.FAILED;
-			this.checkOutput = ok ? 'No spike detected in graphite data' : 'Spike detected in graphite data';
+			if (ok) {
+				this.checkOutput 'No spike detected in graphite data';
+			} else {
+				this.checkOutput = `Spike detected in graphite data. Amount: ${data.sample / data.sample} Threshold: ${this.threshold} `;		    
+			}
 
 		} catch(err) {
 			logger.error({ event: `${logEventPrefix}_ERROR`, url: this.sampleUrl }, err);

--- a/src/checks/graphiteSpike.check.js
+++ b/src/checks/graphiteSpike.check.js
@@ -85,12 +85,13 @@ class GraphiteSpikeCheck extends Check {
 				? data.sample / data.baseline < this.threshold
 				: data.sample / data.baseline > 1 / this.threshold;
 
+			const details = `Direction: ${this.direction} Sample: ${data.sample} Baseline: ${data.baseline} Threshold: ${this.threshold}`
 			if (ok) {
 				this.status = status.PASSED;
-			 	this.checkOutput = 'No spike detected in graphite data';
+			 	this.checkOutput = `No spike detected in graphite data. ${details}`;
 			} else {
 				this.status = status.FAILED;
-				this.checkOutput = `Spike detected in graphite data. Sample: ${data.sample} Baseline: ${data.baseline} Threshold: ${this.threshold}`;
+				this.checkOutput = `Spike detected in graphite data. ${details}`;
 			}
 
 		} catch(err) {


### PR DESCRIPTION
This is in relation to intermittent healthcheck notifications received in the #next-support slack channel. 

Related links: 

- https://github.com/Financial-Times/n-express/pull/476
- https://github.com/Financial-Times/next-myft-api/blob/master/server/libs/health-checks/graphite.js
- https://github.com/Financial-Times/n-health#graphitespike
- https://github.com/Financial-Times/next-myft-api/pull/736
- https://heimdall.in.ft.com/system?code=next-myft-api
- https://runbooks.in.ft.com/next-myft-api
- https://ft-next-myft-api.herokuapp.com/__health

![image](https://user-images.githubusercontent.com/224547/58880472-d87e0300-86cf-11e9-9986-09ca5ae56e5a.png)
