### PR TITLE
Add id field to outputted checks

### DIFF
--- a/src/checks/check.js
+++ b/src/checks/check.js
@@ -31,6 +31,7 @@ They provide essential error handlers. If complex setup is required, define
 an init method returning a Promise`)
 		}
 
+		this.id = opts.id;
 		this.name = opts.name;
 		this.severity = opts.severity;
 		this.businessImpact = opts.businessImpact;
@@ -70,6 +71,7 @@ an init method returning a Promise`)
 
 	getStatus() {
 		const output = {
+			id: this.id,
 			name: this.name,
 			ok: this.status === status.PASSED,
 			severity: this.severity,


### PR DESCRIPTION
The healthcheck standards specify that each individual check requires an id. This adds an id to the check output as an optional argument.

[Healthcheck standards](https://docs.google.com/document/d/18hefJjImF5IFp9WvPAm9Iq5_GmWzI9ahlKSzShpQl1s/edit#)

It may be worth making it required [here](https://github.com/Financial-Times/n-health/pull/122/files#diff-96a27ee154396c4250170560d265b13cR17) but it would be a more significant breaking change

