### PR TITLE
Ops cops: failed Nightly build notification test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,12 +55,28 @@ references:
     branches:
       ignore: /.*/
 
-version: 2
+orbs:
+  slack: circleci/slack@3.4.2
+
+version: 2.1
+
+commands:
+  send_nightly_build_failed_notification:
+    steps:
+      - slack/status:
+          fail_only: true
+          failure_message: Nightly Build failed. Please check the cause to avoid further issues.
+          include_job_number_field: false
+          webhook: ${OPSCOPS_SLACK_WEBHOOK}
 
 jobs:
 
   build:
     <<: *container_config_node8
+    parameters:
+      is_nightly:
+        type: boolean
+        default: false
     steps:
       - checkout
       - run:
@@ -88,9 +104,17 @@ jobs:
           root: *workspace_root
           paths:
             - build
+      - when:
+          condition: << parameters.is_nightly >>
+          steps:
+            - send_nightly_build_failed_notification
 
   test:
     <<: *container_config_node8
+    parameters:
+      is_nightly:
+        type: boolean
+        default: false
     steps:
       - *attach_workspace
       - run:
@@ -104,6 +128,10 @@ jobs:
       - store_artifacts:
           path: test-results
           destination: test-results
+      - when:
+          condition: << parameters.is_nightly >>
+          steps:
+            - send_nightly_build_failed_notification
 
   publish:
     <<: *container_config_node8
@@ -155,10 +183,12 @@ workflows:
     jobs:
       - build:
           context: next-nightly-build
+          is_nightly: true
       - test:
           requires:
             - build
           context: next-nightly-build
+          is_nightly: true
 
 notify:
   webhooks:

--- a/test/startup.spec.js
+++ b/test/startup.spec.js
@@ -14,4 +14,10 @@ describe('Startup', function(){
 		expect(result.get('paywall')).to.be.an.instanceOf(HealthChecks);
 	});
 
+	// TODO: Remove after Ops Cops confirmed the failing nightly build notification was sent
+	// This test was added for this ops cops ticket => https://financialtimes.atlassian.net/browse/NOPS-388
+	it('This test is a part of ops cops expriment. It should fail.', function(){
+		expect(false).to.be.true;
+	});
+
 });


### PR DESCRIPTION
This PR is a part of [this Ops Cops ticket](https://financialtimes.atlassian.net/browse/NOPS-388).
>We would like teams to be notified when nightly builds fail for the apps they own.

This repo was chosen for checking the very beginning of this implementation.
We would like to check whether the failed nightly build notification will be sent correctly.

The test notification will be sent to **Ops Cops team channel** at midnight when nightly build happens.

The circleci build-test for this PR is failed because of this failing test 01049ce, which is a part of this test.