### PR TITLE
Revert "Ops cops: failed Nightly build notification test"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,28 +55,12 @@ references:
     branches:
       ignore: /.*/
 
-orbs:
-  slack: circleci/slack@3.4.2
-
-version: 2.1
-
-commands:
-  send_nightly_build_failed_notification:
-    steps:
-      - slack/status:
-          fail_only: true
-          failure_message: Nightly Build failed. Please check the cause to avoid further issues.
-          include_job_number_field: false
-          webhook: ${OPSCOPS_SLACK_WEBHOOK}
+version: 2
 
 jobs:
 
   build:
     <<: *container_config_node8
-    parameters:
-      is_nightly:
-        type: boolean
-        default: false
     steps:
       - checkout
       - run:
@@ -104,17 +88,9 @@ jobs:
           root: *workspace_root
           paths:
             - build
-      - when:
-          condition: << parameters.is_nightly >>
-          steps:
-            - send_nightly_build_failed_notification
 
   test:
     <<: *container_config_node8
-    parameters:
-      is_nightly:
-        type: boolean
-        default: false
     steps:
       - *attach_workspace
       - run:
@@ -128,10 +104,6 @@ jobs:
       - store_artifacts:
           path: test-results
           destination: test-results
-      - when:
-          condition: << parameters.is_nightly >>
-          steps:
-            - send_nightly_build_failed_notification
 
   publish:
     <<: *container_config_node8
@@ -183,12 +155,10 @@ workflows:
     jobs:
       - build:
           context: next-nightly-build
-          is_nightly: true
       - test:
           requires:
             - build
           context: next-nightly-build
-          is_nightly: true
 
 notify:
   webhooks:

--- a/test/startup.spec.js
+++ b/test/startup.spec.js
@@ -14,10 +14,4 @@ describe('Startup', function(){
 		expect(result.get('paywall')).to.be.an.instanceOf(HealthChecks);
 	});
 
-	// TODO: Remove after Ops Cops confirmed the failing nightly build notification was sent
-	// This test was added for this ops cops ticket => https://financialtimes.atlassian.net/browse/NOPS-388
-	it('This test is a part of ops cops expriment. It should fail.', function(){
-		expect(false).to.be.true;
-	});
-
 });


### PR DESCRIPTION
Reverts Financial-Times/n-health#124

As I posted in platform team channel, https://financialtimes.slack.com/archives/C3TJ6KXEU/p1599753860065800
I confirmed the alert was sent correctly last night.
I'm going to revert this test commits.
<img width="1020" alt="Screenshot 2020-09-11 at 09 57 54" src="https://user-images.githubusercontent.com/21194161/92897658-4a85e180-f415-11ea-8f2e-df661ce364d2.png">
