### PR TITLE
Add failed nightly build slack notification in Circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,19 @@ references:
     branches:
       ignore: /.*/
 
-version: 2
+orbs:
+  slack: circleci/slack@3.4.2
+
+version: 2.1
+
+commands:
+  send_nightly_build_failed_notification:
+    steps:
+      - slack/status:
+          fail_only: true
+          failure_message: Nightly Build failed. Please check the cause to avoid further issues.
+          include_job_number_field: false
+          webhook: ${TEAM_SLACK_WEBHOOK}
 
 jobs:
 
@@ -155,10 +167,14 @@ workflows:
     jobs:
       - build:
           context: next-nightly-build
+          post-steps:
+            - send_nightly_build_failed_notification
       - test:
           requires:
             - build
           context: next-nightly-build
+          post-steps:
+            - send_nightly_build_failed_notification
 
 notify:
   webhooks:


### PR DESCRIPTION
Ops Cops would like teams to be notified when nightly builds fail for the apps they own [Jira](https://financialtimes.atlassian.net/browse/NOPS-388).
This is the improved version of #124 without a failing test.
This repo's failed nightly build notifications are sent to Ops Cops team channel.

<img width="1020" alt="Screenshot 2020-09-11 at 09 57 54" src="https://user-images.githubusercontent.com/21194161/92906782-a7d16100-f41c-11ea-96ee-6f135c4268cc.png">

**TODO in the future**
- Change `TEAM_SLACK_WEBHOOK` in the vault to the team channel's webhook from Ops Cops' one.