### PR TITLE
NOPS-817- Handle Sample and Baseline null values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ Checks if the value of a graphite metric has received data recently.
 #### `cloudWatchThreshold`
 Checks whether the value of a CloudWatch metric has crossed a threshold
 
-_Note: this assumes that `AWS_ACCESS_KEY` & `AWS_SECRET_ACCESS_KEY` are implictly available as environment variables on process.env_
+_Note: this assumes that `AWS_ACCESS_KEY` & `AWS_SECRET_ACCESS_KEY` are implicitly main
+available as environment variables on process.env_
 
 * `cloudWatchRegion` = [default `'eu-west-1'`] AWS region the metrics are stored
 * `cloudWatchMetricName` = [required] Name of the CloudWatch metric to count
@@ -142,7 +143,7 @@ _Note: this assumes that `AWS_ACCESS_KEY` & `AWS_SECRET_ACCESS_KEY` are implictl
 #### `cloudWatchAlarm`
 Checks whether the state of a CloudWatch alarm is health
 
-_Note: this assumes that `AWS_ACCESS_KEY` & `AWS_SECRET_ACCESS_KEY` are implictly available as environment variables on process.env_
+_Note: this assumes that `AWS_ACCESS_KEY` & `AWS_SECRET_ACCESS_KEY` are implicitly available as environment variables on process.env_
 
 * `cloudWatchRegion` = [default `'eu-west-1'`] AWS region the metrics are stored
 * `cloudWatchAlarmName` = [required] Name of the CloudWatch alarm to check

--- a/README.md
+++ b/README.md
@@ -126,8 +126,7 @@ Checks if the value of a graphite metric has received data recently.
 #### `cloudWatchThreshold`
 Checks whether the value of a CloudWatch metric has crossed a threshold
 
-_Note: this assumes that `AWS_ACCESS_KEY` & `AWS_SECRET_ACCESS_KEY` are implicitly main
-available as environment variables on process.env_
+_Note: this assumes that `AWS_ACCESS_KEY` & `AWS_SECRET_ACCESS_KEY` are implicitly available as environment variables on process.env_
 
 * `cloudWatchRegion` = [default `'eu-west-1'`] AWS region the metrics are stored
 * `cloudWatchMetricName` = [required] Name of the CloudWatch metric to count

--- a/src/checks/graphiteSpike.check.js
+++ b/src/checks/graphiteSpike.check.js
@@ -95,9 +95,9 @@ class GraphiteSpikeCheck extends Check {
 			])
 
 			const data = this.normalize({
-				sample: sample[0] ? sample[0].datapoints[0][0] : 0,
+				sample: sample[0] && !Object.is(sample[0].datapoints[0][0], null) ? sample[0].datapoints[0][0] : 0,
 				// baseline should not be allowed to be smaller than one as it is use as a divisor
-				baseline: baseline[0] ? baseline[0].datapoints[0][0] : 1
+				baseline: baseline[0] && !Object.is(baseline[0].datapoints[0][0], null) ? baseline[0].datapoints[0][0] : 1
 			});
 
 			const ok = this.direction === 'up'

--- a/src/checks/graphiteSpike.check.js
+++ b/src/checks/graphiteSpike.check.js
@@ -70,9 +70,9 @@ class GraphiteSpikeCheck extends Check {
 	generateUrl(numerator, divisor, period) {
 		const urlBase = this.ftGraphiteBaseUrl + `from=-${period}&format=json&target=`;
 		if(divisor) {
-			return urlBase + `divideSeries(summarize(${this.seriesFunction}(${numerator}),"${period}","${this.summarizeFunction}",true),summarize(${this.seriesFunction}(${divisor}),"${period}","${this.summarizeFunction}",true))`;
+			return urlBase + `divideSeries(summarize(${this.seriesFunction}(transformNull(${numerator})),"${period}","${this.summarizeFunction}",true),summarize(${this.seriesFunction}(transformNull(${divisor})),"${period}","${this.summarizeFunction}",true))`;
 		} else {
-			return urlBase + `summarize(${this.seriesFunction}(${numerator}),"${period}","${this.summarizeFunction}",true)`;
+			return urlBase + `summarize(${this.seriesFunction}(transformNull(${numerator})),"${period}","${this.summarizeFunction}",true)`;
 		}
 	}
 

--- a/test/graphiteSpike.check.spec.js
+++ b/test/graphiteSpike.check.spec.js
@@ -59,8 +59,8 @@ describe('Graphite Spike Check', function(){
 		check.start();
 		setTimeout(() => {
 
-			expect(mockFetch.firstCall.args[0]).to.contain('from=-10min&format=json&target=summarize(sumSeries(next.metric.200),"10min","sum",true)');
-			expect(mockFetch.secondCall.args[0]).to.contain('from=-7d&format=json&target=summarize(sumSeries(next.metric.200),"7d","sum",true)');
+			expect(mockFetch.firstCall.args[0]).to.contain('from=-10min&format=json&target=summarize(sumSeries(transformNull(next.metric.200)),"10min","sum",true)');
+			expect(mockFetch.secondCall.args[0]).to.contain('from=-7d&format=json&target=summarize(sumSeries(transformNull(next.metric.200)),"7d","sum",true)');
 			expect(check.getStatus().ok).to.be.true;
 			done();
 		});
@@ -74,8 +74,8 @@ describe('Graphite Spike Check', function(){
 		}));
 		check.start();
 		setTimeout(() => {
-			expect(mockFetch.firstCall.args[0]).to.contain('from=-10min&format=json&target=divideSeries(summarize(sumSeries(next.metric.200),"10min","sum",true),summarize(sumSeries(metric.*),"10min","sum",true))');
-			expect(mockFetch.secondCall.args[0]).to.contain('from=-7d&format=json&target=divideSeries(summarize(sumSeries(next.metric.200),"7d","sum",true),summarize(sumSeries(metric.*),"7d","sum",true))');
+			expect(mockFetch.firstCall.args[0]).to.contain('from=-10min&format=json&target=divideSeries(summarize(sumSeries(transformNull(next.metric.200)),"10min","sum",true),summarize(sumSeries(transformNull(metric.*)),"10min","sum",true))');
+			expect(mockFetch.secondCall.args[0]).to.contain('from=-7d&format=json&target=divideSeries(summarize(sumSeries(transformNull(next.metric.200)),"7d","sum",true),summarize(sumSeries(transformNull(metric.*)),"7d","sum",true))');
 			expect(check.getStatus().ok).to.be.true;
 			done();
 		});
@@ -129,8 +129,8 @@ describe('Graphite Spike Check', function(){
 		}));
 		check.start();
 		setTimeout(() => {
-			expect(mockFetch.firstCall.args[0]).to.contain('from=-24h&format=json&target=divideSeries(summarize(sumSeries(next.metric.200),"24h","sum",true),summarize(sumSeries(metric.*),"24h","sum",true))');
-			expect(mockFetch.secondCall.args[0]).to.contain('from=-2d&format=json&target=divideSeries(summarize(sumSeries(next.metric.200),"2d","sum",true),summarize(sumSeries(metric.*),"2d","sum",true))');
+			expect(mockFetch.firstCall.args[0]).to.contain('from=-24h&format=json&target=divideSeries(summarize(sumSeries(transformNull(next.metric.200)),"24h","sum",true),summarize(sumSeries(transformNull(metric.*)),"24h","sum",true))');
+			expect(mockFetch.secondCall.args[0]).to.contain('from=-2d&format=json&target=divideSeries(summarize(sumSeries(transformNull(next.metric.200)),"2d","sum",true),summarize(sumSeries(transformNull(metric.*)),"2d","sum",true))');
 			done();
 		});
 	});

--- a/test/graphiteSpike.check.spec.js
+++ b/test/graphiteSpike.check.spec.js
@@ -177,6 +177,21 @@ describe('Graphite Spike Check', function(){
 			done();
 		});
 	});
+
+	it('Should be possible to handle sample and baseline null values', function(done){
+		mockGraphite([null, null]);
+		check = new Check(getCheckConfig({
+			direction: 'up',
+			threshold: 5,
+			divisor: 'metric.*',
+			normalize: false,
+		}));
+		check.start();
+		setTimeout(() => {
+			expect(check.getStatus().ok).to.be.true;
+			done();
+		});
+	});
 });
 
 


### PR DESCRIPTION
We discovered that there is a situation where we get null values for Sample and Baseline from Graphite, which we aren't handling [here](https://github.com/Financial-Times/n-health/blob/a3cb60053b905fb140607cb84da0029b65a0a99b/src/checks/graphiteSpike.check.js#L98-L100). If Sample and Baseline are both nulls, these [conditions](https://github.com/Financial-Times/n-health/blob/a3cb60053b905fb140607cb84da0029b65a0a99b/src/checks/graphiteSpike.check.js#L104-L105) will be false, and `ok` will also be false. This PR adds [transformNull](https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.transformNull) to the graphite query and an additional check for null values. See [discussion](https://financialtimes.slack.com/archives/C3QLCEZKP/p1620737945147600).

### Tickets
https://financialtimes.atlassian.net/browse/NOPS-817

