### PR TITLE
Added check for 0 baseline as it's used as a divisor

### DIFF
--- a/src/checks/graphiteSpike.check.js
+++ b/src/checks/graphiteSpike.check.js
@@ -94,10 +94,13 @@ class GraphiteSpikeCheck extends Check {
 					.then(fetchres.json)
 			])
 
+			const baselineValue = baseline[0].datapoints[0][0]
+			const sampleValue = sample[0].datapoints[0][0]
+
 			const data = this.normalize({
-				sample: sample[0] && !Object.is(sample[0].datapoints[0][0], null) ? sample[0].datapoints[0][0] : 0,
+				sample: sample[0] && !Object.is(sampleValue, null) ? sampleValue : 0,
 				// baseline should not be allowed to be smaller than one as it is use as a divisor
-				baseline: baseline[0] && !Object.is(baseline[0].datapoints[0][0], null || 0) ? baseline[0].datapoints[0][0] : 1
+				baseline: baseline[0] && !Object.is(baselineValue, null) && !Object.is(baselineValue, 0) ? baselineValue : 1
 			});
 
 			const ok = this.direction === 'up'

--- a/src/checks/graphiteSpike.check.js
+++ b/src/checks/graphiteSpike.check.js
@@ -97,7 +97,7 @@ class GraphiteSpikeCheck extends Check {
 			const data = this.normalize({
 				sample: sample[0] && !Object.is(sample[0].datapoints[0][0], null) ? sample[0].datapoints[0][0] : 0,
 				// baseline should not be allowed to be smaller than one as it is use as a divisor
-				baseline: baseline[0] && !Object.is(baseline[0].datapoints[0][0], null) ? baseline[0].datapoints[0][0] : 1
+				baseline: baseline[0] && !Object.is(baseline[0].datapoints[0][0], null || 0) ? baseline[0].datapoints[0][0] : 1
 			});
 
 			const ok = this.direction === 'up'

--- a/test/graphiteSpike.check.spec.js
+++ b/test/graphiteSpike.check.spec.js
@@ -192,6 +192,22 @@ describe('Graphite Spike Check', function(){
 			done();
 		});
 	});
+
+	it('Should be possible to handle sample and baseline 0 values', function(done){
+		mockGraphite([0, 0]);
+		check = new Check(getCheckConfig({
+			direction: 'up',
+			threshold: 5,
+			divisor: 'metric.*',
+			normalize: false,
+		}));
+		check.start();
+		setTimeout(() => {
+			expect(check.getStatus().ok).to.be.true;
+			done();
+		});
+	});
+
 });
 
 


### PR DESCRIPTION
Graphite is falsely erroring when both baseline and sample are zero, see [issue](https://github.com/Financial-Times/n-health/issues/148). 

This PR adds a check for a baseline of 0 to the check that was recently added for null, and will update the baseline as 1 if that's the case. This is necessary as it is a divisor.