### PR TITLE
Add an option to ignoreNullData to graphiteThreshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ Checks whether the value of a graphite metric has crossed a threshold
 * `direction`: [default: `'above'`] Direction on which to trigger the healthcheck:
 	- `'above'` = alert if value goes above the threshold
 	- `'below'` = alert if value goes below the threshold
+* `ignoreNullData`: [default: `true`]
+	- `true` = only alert if data breaches the threshold, null values are considered healthy
+	- `false` = alert if values breach the threshold or any values are null
 
 #### `graphiteWorking`
 

--- a/src/checks/graphiteThreshold.check.js
+++ b/src/checks/graphiteThreshold.check.js
@@ -19,6 +19,7 @@ class GraphiteThresholdCheck extends Check {
 		this.direction = options.direction || 'above';
 
 		this.samplePeriod = options.samplePeriod || '10min';
+		this.ignoreNullData = options.hasOwnProperty('ignoreNullData') ? options.ignoreNullData : true;
 
 		this.ftGraphiteBaseUrl = 'https://graphitev2-api.ft.com/render/?';
 		this.ftGraphiteKey = process.env.FT_GRAPHITE_KEY;
@@ -48,9 +49,7 @@ class GraphiteThresholdCheck extends Check {
 			const simplifiedResults = results.map(result => {
 				const isFailing = result.datapoints.some(value => {
 					if (value[0] === null) {
-						// metric data is unavailable, we don't fail this threshold check if metric data is unavailable
-						// if you want a failing check for when metric data is unavailable, use graphiteWorking
-						return false;
+						return this.ignoreNullData === true ? false : true;
 					} else {
 						return this.direction === 'above' ?
 							Number(value[0]) > this.threshold :

--- a/test/graphiteThreshold.check.spec.js
+++ b/test/graphiteThreshold.check.spec.js
@@ -173,4 +173,43 @@ describe('Graphite Threshold Check', function(){
 		});
 	});
 
+	context('ignoreNullData option', function () {
+		beforeEach(function(){
+			mockGraphite([
+				{ datapoints: [[null, 1234567890]] },
+			]);
+		});
+
+		it('Should mark null data as healthy by default', function(done){
+			check = new Check(getCheckConfig({}));
+			check.start();
+			setTimeout(() => {
+				expect(check.getStatus().ok).to.be.true;
+				done();
+			});
+		});
+
+		it('Should mark null data as healthy if told to ignoreNullData', function(done){
+			check = new Check(getCheckConfig({
+				ignoreNullData: true,
+			}));
+			check.start();
+			setTimeout(() => {
+				expect(check.getStatus().ok).to.be.true;
+				done();
+			});
+		});
+
+		it('Should mark null data as unhealthy if ignoreNullData is false', function(done){
+			check = new Check(getCheckConfig({
+				ignoreNullData: false,
+			}));
+			check.start();
+			setTimeout(() => {
+				expect(check.getStatus().ok).to.be.false;
+				done();
+			});
+		});
+	});
+
 });


### PR DESCRIPTION
Recently on ft.com we had an incident in which lots of slices disappeared from the homepage.

Ordinarily we have monitoring in the next-front-page application which would have caught this - but the data in Graphite is null when the slices disappear which meant that the health check never failed, so we relied on editorial to inform us of this incident.

<img width="729" alt="Screenshot 2021-08-20 at 17 12 29" src="https://user-images.githubusercontent.com/121219/130262726-0ab35c6d-c128-4518-8a4b-86e578dc6513.png">

In my opinion missing/null data for a healthcheck is more often a sign of a problem than not. However n-health is explicit about ignoring null data, so I thought it was best to add an option rather than reversing the behaviour entirely.

