### PR TITLE
[NOPS-985] Log null data in GraphiteThreshold check

### DIFF
--- a/src/checks/graphiteThreshold.check.js
+++ b/src/checks/graphiteThreshold.check.js
@@ -50,6 +50,10 @@ class GraphiteThresholdCheck extends Check {
 					if (value[0] === null) {
 						// metric data is unavailable, we don't fail this threshold check if metric data is unavailable
 						// if you want a failing check for when metric data is unavailable, use graphiteWorking
+						logger.info({
+							event: `${logEventPrefix}_NULL_DATA`,
+							url: this.sampleUrl,
+						});
 						return false;
 					} else {
 						return this.direction === 'above' ?

--- a/test/graphiteThreshold.check.spec.js
+++ b/test/graphiteThreshold.check.spec.js
@@ -9,6 +9,13 @@ function getCheckConfig (conf) {
 	return Object.assign({}, fixture, conf || {});
 }
 
+const mockLogger = {
+	default: {
+		error: function() {},
+		info: function() {},
+	}
+}
+
 let mockFetch;
 let Check;
 
@@ -21,7 +28,10 @@ function mockGraphite (results) {
 		json : () => Promise.resolve(results)
 	}));
 
-	Check = proxyquire('../src/checks/graphiteThreshold.check', {'node-fetch':mockFetch});
+	Check = proxyquire('../src/checks/graphiteThreshold.check', {
+		'@financial-times/n-logger': mockLogger,
+		'node-fetch': mockFetch,
+	});
 }
 
 describe('Graphite Threshold Check', function(){


### PR DESCRIPTION
In dev huddle today I spoke about the fact that historically we don't alert based on null data.

Some people mentioned this may be due to the reliability of Graphite in the past. I'd like to log the rate that we encounter null data as part of this threshold check with the potential to reverse the behaviour if we find that it's infrequent.