### PR TITLE
NOPS-1034 added handling of summarize(sumSeries) healthchecks

### DIFF
--- a/test/graphiteThreshold.check.spec.js
+++ b/test/graphiteThreshold.check.spec.js
@@ -171,6 +171,87 @@ describe('Graphite Threshold Check', function(){
 
 	});
 
+	context('It handles summarize(sumSeries)', function () {
+
+		it('Should be healthy if sum above lower threshold', function (done) {
+			mockGraphite([
+				{ 
+					datapoints: [
+					[ null, 1635125640],[null,1635129240],[1,1635132840],[1,1635136440],[null,1635140040],[3,1635143640]], 
+					target: 'summarize(sumSeries)'
+				}	
+			]);
+			check = new Check(getCheckConfig({
+				threshold: 1,
+				direction: 'below'
+			}));
+			check.start();
+			setTimeout(() => {
+				expect(check.getStatus().ok).to.be.true;
+				done();
+			});
+		});
+
+		it('Should be healthy if sum below upper threshold', function (done) {
+			mockGraphite([
+				{ datapoints: [
+					[ null, 1635125640],[null,1635129240],[1,1635132840],[1,1635136440],[null,1635140040],[3,1635143640]], 
+					target: 'summarize(sumSeries)'
+				}	
+			]);
+			check = new Check(getCheckConfig({
+				threshold: 8
+			}));
+			check.start();
+			setTimeout(() => {
+				expect(check.getStatus().ok).to.be.true;
+				done();
+			});
+		});
+
+		it('Should be unhealthy if sum above lower threshold', function (done) {
+			mockGraphite([
+				{ datapoints: [
+					[ null, 1635125640],[null,1635129240],[1,1635132840],[1,1635136440],[null,1635140040],[3,1635143640]], 
+					target: 'summarize(sumSeries)'
+
+				}	
+			]);
+			check = new Check(getCheckConfig({
+				threshold: 6,
+				direction: 'below'
+			}));
+			check.start();
+			setTimeout(() => {
+				expect(check.getStatus().ok).to.be.false;
+				done();
+			});
+		});
+
+		it('Should be unhealthy if sum below upper threshold', function (done) {
+			mockGraphite([
+				{ datapoints: [
+					[ null, 1635125640],[null,1635129240],[1,1635132840],[1,1635136440],[null,1635140040],[3,1635143640]], 
+					target: 'summarize(sumSeries)'
+
+				},
+				
+			]);
+			check = new Check(getCheckConfig({
+				threshold: 4
+			}));
+			check.start();
+			setTimeout(() => {
+				expect(check.getStatus().ok).to.be.false;
+				done();
+			});
+		});
+	
+
+
+
+	});
+
 	it('Should be possible to configure sample period', function(done){
 		mockGraphite([{ datapoints: [] }]);
 		check = new Check(getCheckConfig({


### PR DESCRIPTION
Following #158 we've had a bunch of results come up on the dashboard. One thing that we noticed is that all of the problematic health checks included `sumSeries` graphite functionality. 

There are three various functions that use that:
**summarize** (which adds the series), **asPercent** (which adds all of series 1, then all of series 2, then displays them as a percentage of one of the other), and **divideSeries** (presumably adds all of series 1, then all of series 2 and divides one by the other).

The graphite `render` API does not, in fact, return the result of the query / equation if there is more than one datapoint in the datapoints array - and we need to add handling for each of the cases in n-health. In fact even in Grafana the "single integer view" is generated from the points underneath. 

**This PR adds handling for summarize(sumSeries)**.

An example response (from `next-retention`), https://graphitev2-api.ft.com/render/?format=json&from=-12hour&target=summarize(sumSeries(next.heroku.retention.*.prod.manageSubscriptionConfirmationHandler.transition-applyTransition.success),%20%221hour%22,%20%22sum%22,%20true)
```
[{
"datapoints": [[null, 1635125460], [null, 1635129060], [1.0, 1635132660], [1.0, 1635136260], [null, 1635139860], [3.0, 1635143460], [1.0, 1635147060], [1.0, 1635150660], [3.0, 1635154260], [3.0, 1635157860], [null, 1635161460], [2.0, 1635165060]], 
"target": "summarize(sumSeries(next.heroku.retention.*.prod.manageSubscriptionConfirmationHandler.transition-applyTransition.success), \"1hour\", \"sum\", true)", 
"tags": {"aggregatedBy": "sum", "summarize": "1hour", "name": "sumSeries(next.heroku.retention.*.prod.manageSubscriptionConfirmationHandler.transition-applyTransition.success)", "summarizeFunction": "sum"}}]
```

In the original code we have `result.datapoints.some(value => { if (value[0] === null) {...` - what happened in the example above is that for each tuple array in the `datapoints` array the code was checking for `value[0] === null`, and tripping over each `null` for no reason - because in the case of sumSeries, the individual `nulls` don't matter - it is the sums of `value[0]` that does. 

**An alternative solution** which would fix `next-retention` but is likely to trip people up again int he future would be to replace 
_https://graphitev2-api.ft.com/render/?format=json&from=-12hour&target=summarize(sumSeries(next.heroku.retention.*.prod.manageSubscriptionConfirmationHandler.transition-applyTransition.success),%20%221hour%22,%20%22sum%22,%20true)_ 
with 
_https://graphitev2-api.ft.com/render/?format=json&from=-12hour&target=summarize(sumSeries(next.heroku.retention.*.prod.manageSubscriptionConfirmationHandler.transition-applyTransition.success),%20%2212hour%22,%20%22sum%22,%20true)_ 
(from `1hour` to `12hour`). Then we'd only get a single datapoint.