### PR TITLE
NOPS-1034 added threshold handling for asPercent and divideSeries

### DIFF
--- a/src/checks/graphiteThreshold.check.js
+++ b/src/checks/graphiteThreshold.check.js
@@ -52,6 +52,12 @@ class GraphiteThresholdCheck extends Check {
 
 				if(result.target && asPercentRegex.test(result.target) || result.target && divideSeriesRegex.test(result.target)){
 					const fetchCountPerTimeUnit = result.datapoints.map(item => Number(item[0]));
+					if(fetchCountPerTimeUnit.length !== 1){
+						logger.info({
+							event: 'HEALTHCHECK_LENGTH_NOT_1',
+							datapoints: result.datapoints
+						});
+					}
 					const isFailing = this.direction === 'above' ?
 					Number(fetchCountPerTimeUnit[0]) > this.threshold :
 					Number(fetchCountPerTimeUnit[0]) < this.threshold;

--- a/src/checks/graphiteThreshold.check.js
+++ b/src/checks/graphiteThreshold.check.js
@@ -47,6 +47,17 @@ class GraphiteThresholdCheck extends Check {
 			
 			const simplifiedResults = results.map(result => {
 
+				const divideSeriesRegex = /divideSeries\(sumSeries\(.*?\),\s?sumSeries\(.*?\)\)/g; 
+				const asPercentRegex = /asPercent\(summarize\(sumSeries\(.*?\),.*?,.*?,.*?\),\s?summarize\(sumSeries\(.*?\),.*?,.*?,.*?\)\)/g;
+
+				if(result.target && asPercentRegex.test(result.target) || result.target && divideSeriesRegex.test(result.target)){
+					const fetchCountPerTimeUnit = result.datapoints.map(item => Number(item[0]));
+					const isFailing = this.direction === 'above' ?
+					Number(fetchCountPerTimeUnit[0]) > this.threshold :
+					Number(fetchCountPerTimeUnit[0]) < this.threshold;
+					return { target: result.target, isFailing };
+				}
+
 				if(result.target && result.target.includes('summarize(sumSeries')){
 					const fetchCountPerTimeUnit = result.datapoints.map(item => Number(item[0]));
 					const sumUp = (previousValue, currentValue) => previousValue + currentValue;

--- a/test/graphiteThreshold.check.spec.js
+++ b/test/graphiteThreshold.check.spec.js
@@ -173,7 +173,7 @@ describe('Graphite Threshold Check', function(){
 
 	context('It handles summarize(sumSeries)', function () {
 
-		it('Should be healthy if sum above lower threshold', function (done) {
+		it('Should be healthy if sum above threshold', function (done) {
 			mockGraphite([
 				{ 
 					datapoints: [
@@ -192,7 +192,7 @@ describe('Graphite Threshold Check', function(){
 			});
 		});
 
-		it('Should be healthy if sum below upper threshold', function (done) {
+		it('Should be healthy if sum below threshold', function (done) {
 			mockGraphite([
 				{ datapoints: [
 					[ null, 1635125640],[null,1635129240],[1,1635132840],[1,1635136440],[null,1635140040],[3,1635143640]], 
@@ -209,7 +209,7 @@ describe('Graphite Threshold Check', function(){
 			});
 		});
 
-		it('Should be unhealthy if sum above lower threshold', function (done) {
+		it('Should be unhealthy if sum below threshold', function (done) {
 			mockGraphite([
 				{ datapoints: [
 					[ null, 1635125640],[null,1635129240],[1,1635132840],[1,1635136440],[null,1635140040],[3,1635143640]], 
@@ -228,7 +228,7 @@ describe('Graphite Threshold Check', function(){
 			});
 		});
 
-		it('Should be unhealthy if sum below upper threshold', function (done) {
+		it('Should be unhealthy if sum above threshold', function (done) {
 			mockGraphite([
 				{ datapoints: [
 					[ null, 1635125640],[null,1635129240],[1,1635132840],[1,1635136440],[null,1635140040],[3,1635143640]], 
@@ -246,10 +246,158 @@ describe('Graphite Threshold Check', function(){
 				done();
 			});
 		});
-	
+	});
 
+	context('It handles asPercent', function () {
 
+		it('Should be healthy if above threshold', function (done) {
+			mockGraphite([
+				{ 
+					datapoints: [
+					[ 8, 1635125640]], 
+					target: `asPercent(summarize(sumSeries(failure.count), '10min', 'sum', true), summarize(sumSeries(success.count), '10min', 'sum', true))`
+				}	
+			]);
 
+			check = new Check(getCheckConfig({
+				threshold: 1,
+				direction: 'below'
+			}));
+			check.start();
+			setTimeout(() => {
+				expect(check.getStatus().ok).to.be.true;
+				done();
+			});
+		});
+
+		it('Should be healthy if below threshold', function (done) {
+			mockGraphite([
+				{ datapoints: [
+					[ null, 1635125640]], 
+					target: `asPercent(summarize(sumSeries(failure.count), '10min', 'sum', true), summarize(sumSeries(success.count), '10min', 'sum', true))`
+				}	
+			]);
+			check = new Check(getCheckConfig({
+				threshold: 1
+			}));
+			check.start();
+			setTimeout(() => {
+				expect(check.getStatus().ok).to.be.true;
+				done();
+			});
+		});
+
+		it('Should be unhealthy if above threshold', function (done) {
+			mockGraphite([
+				{ datapoints: [
+					[ 8, 1635125640]], 
+					target: `asPercent(summarize(sumSeries(failure.count), '10min', 'sum', true),summarize(sumSeries(success.count), '10min', 'sum', true))`
+				}	
+			]);
+			check = new Check(getCheckConfig({
+				threshold: 5,
+			}));
+			check.start();
+			setTimeout(() => {
+				expect(check.getStatus().ok).to.be.false;
+				done();
+			});
+		});
+
+		it('Should be unhealthy if below threshold', function (done) {
+			mockGraphite([
+				{ datapoints: [
+					[ null, 1635125640]], 
+					target: `asPercent(summarize(sumSeries(failure.count), '10min', 'sum', true), summarize(sumSeries(success.count), '10min', 'sum', true))`
+				},
+				
+			]);
+			check = new Check(getCheckConfig({
+				threshold: 4,
+				direction: 'below'
+
+			}));
+			check.start();
+			setTimeout(() => {
+				expect(check.getStatus().ok).to.be.false;
+				done();
+			});
+		});
+	});
+
+	context('It handles divideSeries', function () {
+
+		it('Should be healthy if above threshold', function (done) {
+			mockGraphite([
+				{ 
+					datapoints: [
+					[ 8, 1635125640]], 
+					target: `divideSeries(sumSeries(error.count), sumSeries(status.*.count))`
+				}	
+			]);
+
+			check = new Check(getCheckConfig({
+				threshold: 1,
+				direction: 'below'
+			}));
+			check.start();
+			setTimeout(() => {
+				expect(check.getStatus().ok).to.be.true;
+				done();
+			});
+		});
+
+		it('Should be healthy if below threshold', function (done) {
+			mockGraphite([
+				{ datapoints: [
+					[ null, 1635125640]], 
+					target: `divideSeries(sumSeries(error.count), sumSeries(status.*.count))`
+				}	
+			]);
+			check = new Check(getCheckConfig({
+				threshold: 1
+			}));
+			check.start();
+			setTimeout(() => {
+				expect(check.getStatus().ok).to.be.true;
+				done();
+			});
+		});
+
+		it('Should be unhealthy if above threshold', function (done) {
+			mockGraphite([
+				{ datapoints: [
+					[ 8, 1635125640]], 
+					target: `divideSeries(sumSeries(error.count),sumSeries(status.*.count))`
+				}	
+			]);
+			check = new Check(getCheckConfig({
+				threshold: 5,
+			}));
+			check.start();
+			setTimeout(() => {
+				expect(check.getStatus().ok).to.be.false;
+				done();
+			});
+		});
+
+		it('Should be unhealthy if below threshold', function (done) {
+			mockGraphite([
+				{ datapoints: [
+					[ null, 1635125640]], 
+					target: `divideSeries(sumSeries(error.count), sumSeries(status.*.count))`
+				},			
+			]);
+			check = new Check(getCheckConfig({
+				threshold: 4,
+				direction: 'below'
+			}));
+			check.start();
+			setTimeout(() => {
+				expect(check.getStatus().ok).to.be.false;
+				done();
+			});
+		});
 	});
 
 	it('Should be possible to configure sample period', function(done){


### PR DESCRIPTION
Companion to #164 

Graphite datapoints are values stored with their timestamp. But, if there are no events during that timestamp, the value will be `null` and not `0`, ie denoting explicit lack of a value. (https://graphite.readthedocs.io/en/latest/terminology.html#graphite-terminology). So in some cases `null` is an expected - and even desirable value. For example if we're checking the `error.count` then `0` is ideal as that means no errors are occurring. 

Things get a little bit interesting when we look at `asPercent` and `divideSeries`. Those two graphite functions are used in the same way - we take a `sum of errors in _time_` and a `sum of successes in _time_` and we either express the result as a percentage or division result. I think the desired metrics is the ratio of errors to successes; I'm not quite sure either `asPercent` or `divideSeries` reflects that, but it's good enough to be used as a valid metric. Anyhow, what this means is practice is most of the time `sum of successes = _positive integer_` and `sum of errors = null (ie 0)`. But `zero  divided by positive integer` is still `zero` (for **divideSeries**), and `zero times 100, then divided by positive integer` is also `zero` (for **asPercent**).

**What this PR does**
- it adds custom handling for `asPercent` and `divideSeries`
- simplifies test headers for `sumSeries` because I got very confused 

**What this PR does not do**
My initial though would be - once we checked that the result of `asPercent` or `divideSeries` was `null`, we'd run a `fetch` against the second metric of the check and fail if that's `null` too. I totally forgot you can't do `await` inside a `map`. As such we have two options: 1️⃣  merge this PR and call it done, given that's an improvement on what was there before; and 2️⃣  if we are really concerned about the possibility of Graphite being the weak point, we should go through the repos that are using those checks and add a `n-health` `graphiteWorking` check. 

**When reviewing this PR** please state your preference for 1️⃣  vs 2️⃣  vs any other thought you might have on this matter. 

