### PR TITLE
FTDCS-33 added logs to failing graphiteSpike checks

### DIFF
--- a/src/checks/graphiteSpike.check.js
+++ b/src/checks/graphiteSpike.check.js
@@ -36,6 +36,8 @@ class GraphiteSpikeCheck extends Check {
 		super(options);
 		this.threshold = options.threshold || 3;
 		this.direction = options.direction || 'up';
+		this.id = options.id;
+		this.name = options.name;
 
 		this.samplePeriod = options.samplePeriod || '10min';
 		this.baselinePeriod = options.baselinePeriod || '7d';
@@ -114,6 +116,22 @@ class GraphiteSpikeCheck extends Check {
 			} else {
 				this.status = status.FAILED;
 				this.checkOutput = `Spike detected in graphite data. ${details}`;
+				logger.warn({
+					event: "graphiteSpike fail",
+					checkId: this.id,
+					checkName: this.name,
+					threshold: this.threshold,
+					sampleDetails: {
+						url: this.sampleUrl,
+						rawValue: sampleValue,
+						normalisedValue: data.sample
+					},
+					baselineDetails: {
+						url: this.baselineUrl,
+						rawValue: baselineValue,
+						normalisedValue: data.baseline
+					},
+				})
 			}
 
 		} catch(err) {


### PR DESCRIPTION
Next-health has this health check: https://github.com/Financial-Times/next-health/blob/main/server/config/health-checks/platform.js. It is very flappy. The flaps are ephemeral - such at that if you click on "healthcheck source" in Heimdall immediately after it goes red, you'll get a "all healthy" source logs. As we can't see what numbers are triggering the flaps, it is really difficult - bordering on impossible - to fix the source of the problem. We are hoping that this log will help us **see** what is wrong when the flaps happen and act accordingly. 

Q: Why just graphiteSpike, and not all of the checks?
A: This has a potential to be noisy and expensive. I would love to add this to all of the checks, but I want to use this one as a trial to see if it actually does give the information we want, and if that information is as useful as we hoped. 