### PR TITLE
FTDCS-196 - Added default panic guide for Fastly key expiration check

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,10 @@ _Note: this assumes that `AWS_ACCESS_KEY` & `AWS_SECRET_ACCESS_KEY` are implicit
 #### `fastlyKeyExpiration`
 Checks if the expiration date of a Fastly key is due for the next 2 weeks
 
-_Note: there is a default panic guide for this check 'Contact the Slack channel #fastly-support to rotate the keys https://financialtimes.slack.com/archives/C2GFE1C9X'_
+_Note: there are some default properties_
+** _panic guide: 'Contact the Slack channel #fastly-support to rotate the keys https://financialtimes.slack.com/archives/C2GFE1C9X'_
+** _technicalSummary: 'Check the Fastly key in the api token information endpoint to obtain the expiration date'_
+** _severity = 2_
 
 * `fastlyKey` =  The value of the fastly key to check
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ _Note: this assumes that `AWS_ACCESS_KEY` & `AWS_SECRET_ACCESS_KEY` are implicit
 #### `fastlyKeyExpiration`
 Checks if the expiration date of a Fastly key is due for the next 2 weeks
 
+_Note: there is a default panic guide for this check 'Contact the Slack channel #fastly-support to rotate the keys https://financialtimes.slack.com/archives/C2GFE1C9X'_
+
 * `fastlyKey` =  The value of the fastly key to check
 
 _Note: if the expiration date is past, the severity level is 1_

--- a/src/checks/fastlyKeyExpiration.check.js
+++ b/src/checks/fastlyKeyExpiration.check.js
@@ -5,6 +5,7 @@ const Check = require('./check');
 const status = require('./status');
 
 const fastlyApiEndpoint = 'https://api.fastly.com/tokens/self';
+const defaultPanicGuide = 'Contact the Slack channel #fastly-support to rotate the keys https://financialtimes.slack.com/archives/C2GFE1C9X',
 /**
  * @description Polls the current state of a Fastly key expiration date
  * alert if the key expires in the next week or two
@@ -14,6 +15,7 @@ class FastlyKeyExpirationCheck extends Check {
 	constructor(options) {
 		super(options);
 		this.fastlyKey = options.fastlyKey;
+		this.panicGuide options.panicGuide || defaultPanicGuide;
 		this.states = Object.freeze({
 			PENDING: {
 				status: status.PENDING,

--- a/src/checks/fastlyKeyExpiration.check.js
+++ b/src/checks/fastlyKeyExpiration.check.js
@@ -5,7 +5,7 @@ const Check = require('./check');
 const status = require('./status');
 
 const fastlyApiEndpoint = 'https://api.fastly.com/tokens/self';
-const defaultPanicGuide = 'Contact the Slack channel #fastly-support to rotate the keys https://financialtimes.slack.com/archives/C2GFE1C9X';
+const defaultPanicGuide = 'Generate a new key in your own Fastly account with the same permissions and update it in Vault or your app';
 const defaultTechnicalSummary = 'Check the Fastly key in the api token information endpoint to obtain the expiration date';
 const defaultSeverity = 2;
 /**

--- a/src/checks/fastlyKeyExpiration.check.js
+++ b/src/checks/fastlyKeyExpiration.check.js
@@ -5,7 +5,9 @@ const Check = require('./check');
 const status = require('./status');
 
 const fastlyApiEndpoint = 'https://api.fastly.com/tokens/self';
-const defaultPanicGuide = 'Contact the Slack channel #fastly-support to rotate the keys https://financialtimes.slack.com/archives/C2GFE1C9X',
+const defaultPanicGuide = 'Contact the Slack channel #fastly-support to rotate the keys https://financialtimes.slack.com/archives/C2GFE1C9X';
+const defaultTechnicalSummary: 'Check the Fastly key in the api token information endpoint to obtain the expiration date';
+const defaultSeverity = 2;
 /**
  * @description Polls the current state of a Fastly key expiration date
  * alert if the key expires in the next week or two
@@ -15,7 +17,9 @@ class FastlyKeyExpirationCheck extends Check {
 	constructor(options) {
 		super(options);
 		this.fastlyKey = options.fastlyKey;
-		this.panicGuide options.panicGuide || defaultPanicGuide;
+		this.panicGuide = options.panicGuide || defaultPanicGuide;
+		this.technicalSummary = options.technicalSummary || defaultTechnicalSummary;
+		this.severity = options.severity || defaultSeverity;
 		this.states = Object.freeze({
 			PENDING: {
 				status: status.PENDING,

--- a/src/checks/fastlyKeyExpiration.check.js
+++ b/src/checks/fastlyKeyExpiration.check.js
@@ -6,7 +6,7 @@ const status = require('./status');
 
 const fastlyApiEndpoint = 'https://api.fastly.com/tokens/self';
 const defaultPanicGuide = 'Contact the Slack channel #fastly-support to rotate the keys https://financialtimes.slack.com/archives/C2GFE1C9X';
-const defaultTechnicalSummary: 'Check the Fastly key in the api token information endpoint to obtain the expiration date';
+const defaultTechnicalSummary = 'Check the Fastly key in the api token information endpoint to obtain the expiration date';
 const defaultSeverity = 2;
 /**
  * @description Polls the current state of a Fastly key expiration date


### PR DESCRIPTION
The panic guide is the same for any fastly key, so there is no point to repeat the same in each configuration health check.
Anyway, there is the option to set a custom panic guide, just in case.