### PR TITLE
Add a Heroku log drain check type

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Checks if the value of a graphite metric has received data recently.
 Checks whether a Heroku log drain is configured correctly for the app. We determine the validity of a log drain based on [the "Logging to Splunk from Heroku" guide here](https://tech.in.ft.com/tech-topics/logging/splunk/logging-from-heroku#configuration).
 
 * `herokuAuthToken` = [default `process.env.HEROKU_AUTH_TOKEN`] an auth token with read access on the Heroku app
-* `herokuAppId` = [default `process.env.HEROKU_APP_ID`] the Heroku UUID for the Heroku app
+* `herokuAppId` = [default `process.env.HEROKU_APP_ID`] the Heroku UUID for the Heroku app, which should be provided by the [Heroku runtime-dyno-metadata feature](https://devcenter.heroku.com/articles/dyno-metadata).
 
 
 #### `cloudWatchThreshold`

--- a/README.md
+++ b/README.md
@@ -124,6 +124,14 @@ Checks if the value of a graphite metric has received data recently.
 	- Use `summarize` if the metric receives data infrequently, e.g. `summarize(next.heroku.next-article.some-infrequent-periodic-metric, '30mins', 'sum', true)`
 * `time`: [default: `'-5minutes'`] Length of time to count metrics
 
+#### `herokuLogDrain`
+
+Checks whether a Heroku log drain is configured correctly for the app. We determine the validity of a log drain based on [the "Logging to Splunk from Heroku" guide here](https://tech.in.ft.com/tech-topics/logging/splunk/logging-from-heroku#configuration).
+
+* `herokuAuthToken` = [default `process.env.HEROKU_AUTH_TOKEN`] an auth token with read access on the Heroku app
+* `herokuAppId` = [default `process.env.HEROKU_APP_ID`] the Heroku UUID for the Heroku app
+
+
 #### `cloudWatchThreshold`
 Checks whether the value of a CloudWatch metric has crossed a threshold
 

--- a/secrets.js
+++ b/secrets.js
@@ -1,6 +1,8 @@
 module.exports = {
 	whitelist: [
+		'7883555001', // src/checks/herokuLogDrain.check.js
 		'23077025-960d-11e6-afcc-07964ee4b5be', // test/fixtures/cloudWatchThresholdResponse.json
-		'f8585BOxnGQDMbnkJoM1e' // test/fixtures/config/graphiteWorkingFixture.js
+		'f8585BOxnGQDMbnkJoM1e', // test/fixtures/config/graphiteWorkingFixture.js
+		'mock-splunk-token@http-inputs-financialtimes.splunkcloud.com' // test/herokuLogDrain.check.spec.js
 	]
 };

--- a/src/checks/herokuLogDrain.check.js
+++ b/src/checks/herokuLogDrain.check.js
@@ -1,0 +1,123 @@
+const fetch = require('node-fetch');
+const logger = require('@financial-times/n-logger').default;
+const Check = require('./check');
+const status = require('./status');
+
+const defaultPanicGuide = '[Check whether the app has been migrated to use log drains](https://financialtimes.atlassian.net/wiki/spaces/DS/pages/7883555001/Migrating+an+app+to+Heroku+log+drains). If it has been migrated then the log drain is either misconfigured or missing, follow the migration guide to correct this.';
+const defaultTechnicalSummary = 'Uses the Heroku API to fetch Heroku log drains for the application and verify that they\'re configured to drain into the correct Splunk endpoint.';
+const defaultBusinessImpact = 'Logs may not be captured in Splunk for this application. It may not be possible to debug other issues while log drains are not configured.';
+const defaultSeverity = 2;
+
+class HerokuLogDrainCheck extends Check {
+
+	constructor({
+		panicGuide = defaultPanicGuide,
+		technicalSummary = defaultTechnicalSummary,
+		businessImpact = defaultBusinessImpact,
+		severity = defaultSeverity,
+		herokuAuthToken = process.env.HEROKU_AUTH_TOKEN,
+		herokuAppId = process.env.HEROKU_APP_ID,
+		...options
+	}) {
+		super({ panicGuide, technicalSummary, businessImpact, severity, ...options });
+		this.herokuAuthToken = herokuAuthToken;
+		this.herokuAppId = herokuAppId;
+	}
+
+	validateHerokuConfig() {
+		if (!this.herokuAuthToken) {
+			throw new Error('A Heroku auth token is required to run this check. `HEROKU_AUTH_TOKEN` env var was missing');
+		}
+		if (!this.herokuAppId) {
+			throw new Error('A Heroku app ID is required to run this check. `HEROKU_APP_ID` env var was missing');
+		}
+	}
+
+	get logDrainApiEndpoint() {
+		return `https://api.heroku.com/apps/${this.herokuAppId}/log-drains`;
+	}
+
+	async getLogDrains() {
+		const response = await fetch(this.logDrainApiEndpoint, {
+			headers: {
+				accept: 'application/vnd.heroku+json; version=3',
+				authorization: `Bearer ${this.herokuAuthToken}`,
+				'user-agent': `Heroku App ${this.herokuAppId}`
+			}
+		});
+		if (!response.ok) {
+			throw new Error(`heroku responded with a ${response.status} status code`);
+		}
+		return response.json();
+	}
+
+	validateLogDrains(logDrains) {
+		if (!logDrains.length) {
+			throw new Error('app has no log drain configured');
+		}
+		if (logDrains.length > 1) {
+			throw new Error('app has more than one log drain configured');
+		}
+		this.validateLogDrainUrl(`${logDrains[0]?.url}`);
+	}
+
+	validateLogDrainUrl(url) {
+		let parsedUrl;
+		try {
+			parsedUrl = new URL(url);
+		} catch (error) {
+			throw new Error('log drain is not a valid URL');
+		}
+
+		if (
+			parsedUrl.protocol !== 'https:' ||
+			parsedUrl.hostname !== 'http-inputs-financialtimes.splunkcloud.com' ||
+			parsedUrl.pathname !== '/services/collector/raw' ||
+			parsedUrl.username !== 'x' ||
+			!parsedUrl.password
+		) {
+			throw new Error('log drain URL does not match "https://x:<token>@http-inputs-financialtimes.splunkcloud.com/services/collector/raw"');
+		}
+
+		if (!parsedUrl.searchParams.get('source') || (process.env.SYSTEM_CODE && parsedUrl.searchParams.get('source') !== process.env.SYSTEM_CODE)) {
+			throw new Error('log drain source parameter is not set to the application system code');
+		}
+
+		if (parsedUrl.searchParams.get('sourcetype') !== 'heroku') {
+			throw new Error('log drain sourcetype parameter is not set to "heroku"');
+		}
+
+		if (!parsedUrl.searchParams.get('host')) {
+			throw new Error('log drain host parameter is not set');
+		}
+
+		if (!parsedUrl.searchParams.get('channel')) {
+			throw new Error('log drain channel parameter is not set');
+		}
+	}
+
+	async tick() {
+		try {
+			this.validateHerokuConfig();
+			const logDrains = await this.getLogDrains();
+
+			try {
+				this.validateLogDrains(logDrains);
+			} catch (error) {
+				this.status = status.FAILED;
+				this.checkOutput = `Heroku log drains are misconfigured: ${error.message}`;
+				return;
+			}
+
+			this.status = status.PASSED;
+			this.checkOutput = 'Heroku log drain configuration is correct';
+
+		} catch (error) {
+			logger.error('Failed to get Heroku log drain information', error);
+			this.status = status.FAILED;
+			this.checkOutput = `Heroku log drain configuration check failed to fetch data: ${error.message}`;
+		}
+	}
+}
+
+module.exports = HerokuLogDrainCheck;

--- a/src/checks/herokuLogDrain.check.js
+++ b/src/checks/herokuLogDrain.check.js
@@ -29,7 +29,7 @@ class HerokuLogDrainCheck extends Check {
 			throw new Error('A Heroku auth token is required to run this check. `HEROKU_AUTH_TOKEN` env var was missing');
 		}
 		if (!this.herokuAppId) {
-			throw new Error('A Heroku app ID is required to run this check. `HEROKU_APP_ID` env var was missing');
+			throw new Error('A Heroku app ID is required to run this check. Please enable the runtime-dyno-metadata labs feature');
 		}
 	}
 

--- a/src/checks/herokuLogDrain.check.js
+++ b/src/checks/herokuLogDrain.check.js
@@ -79,7 +79,12 @@ class HerokuLogDrainCheck extends Check {
 			throw new Error('log drain URL does not match "https://x:<token>@http-inputs-financialtimes.splunkcloud.com/services/collector/raw"');
 		}
 
-		if (!parsedUrl.searchParams.get('source') || (process.env.SYSTEM_CODE && parsedUrl.searchParams.get('source') !== process.env.SYSTEM_CODE)) {
+		const hasCorrectSourceParam = (
+			process.env.SYSTEM_CODE ?
+				parsedUrl.searchParams.get('source') === process.env.SYSTEM_CODE :
+				true
+		);
+		if (!parsedUrl.searchParams.get('source') || !hasCorrectSourceParam) {
 			throw new Error('log drain source parameter is not set to the application system code');
 		}
 

--- a/src/checks/index.js
+++ b/src/checks/index.js
@@ -9,6 +9,7 @@ module.exports = {
 	graphiteSpike: require('./graphiteSpike.check'),
 	graphiteThreshold: require('./graphiteThreshold.check'),
 	graphiteWorking: require('./graphiteWorking.check'),
+	herokuLogDrain: require('./herokuLogDrain.check'),
 	cloudWatchAlarm: require('./cloudWatchAlarm.check'),
 	cloudWatchThreshold: require('./cloudWatchThreshold.check'),
 	fastlyKeyExpiration: require('./fastlyKeyExpiration.check')

--- a/test/herokuLogDrain.check.spec.js
+++ b/test/herokuLogDrain.check.spec.js
@@ -337,7 +337,7 @@ describe.only('Heroku Log Drain Check', () => {
 
 		it('it sets the check properties to indicate failure', () => {
 			const status = check.getStatus();
-			expect(status.checkOutput).to.equal('Heroku log drain configuration check failed to fetch data: A Heroku app ID is required to run this check. `HEROKU_APP_ID` env var was missing');
+			expect(status.checkOutput).to.equal('Heroku log drain configuration check failed to fetch data: A Heroku app ID is required to run this check. Please enable the runtime-dyno-metadata labs feature');
 			expect(status.ok).to.be.false;
 		});
 

--- a/test/herokuLogDrain.check.spec.js
+++ b/test/herokuLogDrain.check.spec.js
@@ -1,0 +1,348 @@
+'use strict';
+
+const expect = require('chai').expect;
+const proxyquire = require('proxyquire').noCallThru().noPreserveCache();
+const sinon = require('sinon');
+
+const mockFetch = sinon.stub();
+
+const mockValidResponse = {
+	status: 200,
+	ok: true,
+	json: sinon.stub().resolves([
+		{
+			url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?sourcetype=heroku&source=mock-system-code&host=mock-host&channel=mock-channel'
+		}
+	])
+};
+
+const mockInvalidResponse = {
+	status: 403,
+	ok: false
+};
+
+mockFetch.withArgs('https://api.heroku.com/apps/mock-valid-app-id/log-drains').resolves(mockValidResponse);
+mockFetch.withArgs('https://api.heroku.com/apps/mock-invalid-app-id/log-drains').resolves(mockInvalidResponse);
+
+const Check = proxyquire('../src/checks/herokuLogDrain.check', {
+	'node-fetch': mockFetch,
+	'@financial-times/n-logger': {default: {
+		error: sinon.spy()
+	}}
+});
+
+describe.only('Heroku Log Drain Check', () => {
+	let check;
+	let backupEnv;
+
+	beforeEach(() => {
+		backupEnv = process.env;
+		process.env.SYSTEM_CODE = 'mock-system-code';
+		process.env.HEROKU_AUTH_TOKEN = 'mock-env-auth-token';
+		process.env.HEROKU_APP_ID = 'mock-env-app-id';
+		check = new Check({
+			id: 'mock-id',
+			name: 'mock-name',
+			herokuAuthToken: 'mock-auth-token',
+			herokuAppId: 'mock-valid-app-id'
+		});
+	});
+
+	afterEach(() => {
+		process.env = backupEnv;
+		check.stop();
+		sinon.resetHistory();
+	});
+
+	it('extends the base Check class', () => {
+		expect(check).to.be.an.instanceof(require('../src/checks/check'));
+	});
+
+	it('it has sensible default check values', () => {
+		const status = check.getStatus();
+		expect(status.severity).to.equal(2);
+		expect(status.businessImpact).to.equal('Logs may not be captured in Splunk for this application. It may not be possible to debug other issues while log drains are not configured.');
+		expect(status.technicalSummary).to.equal('Uses the Heroku API to fetch Heroku log drains for the application and verify that they\'re configured to drain into the correct Splunk endpoint.');
+		expect(status.panicGuide).to.equal('[Check whether the app has been migrated to use log drains](https://financialtimes.atlassian.net/wiki/spaces/DS/pages/7883555001/Migrating+an+app+to+Heroku+log+drains). If it has been migrated then the log drain is either misconfigured or missing, follow the migration guide to correct this.');
+	});
+
+	describe('when the app has a valid Heroku log drain configured', () => {
+
+		beforeEach(done => {
+			check.start();
+			setTimeout(done);
+		});
+
+		it('requests the Heroku log drains for the app', () => {
+			expect(mockFetch.callCount).to.equal(1);
+			expect(mockFetch.firstCall.args[0]).to.equal('https://api.heroku.com/apps/mock-valid-app-id/log-drains');
+			expect(mockFetch.firstCall.args[1].headers).to.be.an('object');
+			expect(mockFetch.firstCall.args[1].headers.accept).to.equal('application/vnd.heroku+json; version=3');
+			expect(mockFetch.firstCall.args[1].headers.authorization).to.equal('Bearer mock-auth-token');
+		});
+
+		it('it sets the check properties to indicate success', () => {
+			const status = check.getStatus();
+			expect(status.checkOutput).to.equal('Heroku log drain configuration is correct');
+			expect(status.ok).to.be.true;
+		});
+
+	});
+
+	describe('when the Heroku API fails', () => {
+
+		beforeEach(done => {
+			check.herokuAppId = 'mock-invalid-app-id';
+			check.start();
+			setTimeout(done);
+		});
+
+		it('requests the Heroku log drains for the app', () => {
+			expect(mockFetch.callCount).to.equal(1);
+			expect(mockFetch.firstCall.args[0]).to.equal('https://api.heroku.com/apps/mock-invalid-app-id/log-drains');
+		});
+
+		it('it sets the check properties to indicate failure', () => {
+			const status = check.getStatus();
+			expect(status.checkOutput).to.equal('Heroku log drain configuration check failed to fetch data: heroku responded with a 403 status code');
+			expect(status.ok).to.be.false;
+		});
+
+	});
+
+	describe('when the app has multiple log drains', () => {
+
+		beforeEach(done => {
+			mockValidResponse.json.resolves([
+				{
+					url: 'mock-drain-1'
+				},
+				{
+					url: 'mock-drain-2'
+				}
+			]);
+			check.start();
+			setTimeout(done);
+		});
+
+		it('it sets the check properties to indicate failure', () => {
+			const status = check.getStatus();
+			expect(status.checkOutput).to.equal('Heroku log drains are misconfigured: app has more than one log drain configured');
+			expect(status.ok).to.be.false;
+		});
+
+	});
+
+	describe('when the app has no log drains', () => {
+
+		beforeEach(done => {
+			mockValidResponse.json.resolves([]);
+			check.start();
+			setTimeout(done);
+		});
+
+		it('it sets the check properties to indicate failure', () => {
+			const status = check.getStatus();
+			expect(status.checkOutput).to.equal('Heroku log drains are misconfigured: app has no log drain configured');
+			expect(status.ok).to.be.false;
+		});
+
+	});
+
+	describe('when the app has an invalid URL as a log drain', () => {
+
+		beforeEach(done => {
+			mockValidResponse.json.resolves([
+				{
+					url: 'log-drain'
+				}
+			]);
+			check.start();
+			setTimeout(done);
+		});
+
+		it('it sets the check properties to indicate failure', () => {
+			const status = check.getStatus();
+			expect(status.checkOutput).to.equal('Heroku log drains are misconfigured: log drain is not a valid URL');
+			expect(status.ok).to.be.false;
+		});
+
+	});
+
+	describe('when the app has the wrong log drain configured', () => {
+
+		beforeEach(done => {
+			mockValidResponse.json.resolves([
+				{
+					url: 'https://logdrain.example.com/'
+				}
+			]);
+			check.start();
+			setTimeout(done);
+		});
+
+		it('it sets the check properties to indicate failure', () => {
+			const status = check.getStatus();
+			expect(status.checkOutput).to.equal('Heroku log drains are misconfigured: log drain URL does not match "https://x:<token>@http-inputs-financialtimes.splunkcloud.com/services/collector/raw"');
+			expect(status.ok).to.be.false;
+		});
+
+	});
+
+	describe('when the app log drain has no source query parameter', () => {
+
+		beforeEach(done => {
+			mockValidResponse.json.resolves([
+				{
+					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?sourcetype=heroku&host=mock-host&channel=mock-channel'
+				}
+			]);
+			check.start();
+			setTimeout(done);
+		});
+
+		it('it sets the check properties to indicate failure', () => {
+			const status = check.getStatus();
+			expect(status.checkOutput).to.equal('Heroku log drains are misconfigured: log drain source parameter is not set to the application system code');
+			expect(status.ok).to.be.false;
+		});
+
+	});
+
+	describe('when the app log drain source query parameter does not match the SYSTEM_CODE environment variable', () => {
+
+		beforeEach(done => {
+			mockValidResponse.json.resolves([
+				{
+					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?sourcetype=heroku&source=invalid&host=mock-host&channel=mock-channel'
+				}
+			]);
+			check.start();
+			setTimeout(done);
+		});
+
+		it('it sets the check properties to indicate failure', () => {
+			const status = check.getStatus();
+			expect(status.checkOutput).to.equal('Heroku log drains are misconfigured: log drain source parameter is not set to the application system code');
+			expect(status.ok).to.be.false;
+		});
+
+	});
+
+	describe('when the app log drain has an invalid sourcetype query parameter', () => {
+
+		beforeEach(done => {
+			mockValidResponse.json.resolves([
+				{
+					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?sourcetype=invalid&source=mock-system-code&host=mock-host&channel=mock-channel'
+				}
+			]);
+			check.start();
+			setTimeout(done);
+		});
+
+		it('it sets the check properties to indicate failure', () => {
+			const status = check.getStatus();
+			expect(status.checkOutput).to.equal('Heroku log drains are misconfigured: log drain sourcetype parameter is not set to "heroku"');
+			expect(status.ok).to.be.false;
+		});
+
+	});
+
+	describe('when the app log drain has no host query parameter', () => {
+
+		beforeEach(done => {
+			mockValidResponse.json.resolves([
+				{
+					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?sourcetype=heroku&source=mock-system-code&channel=mock-channel'
+				}
+			]);
+			check.start();
+			setTimeout(done);
+		});
+
+		it('it sets the check properties to indicate failure', () => {
+			const status = check.getStatus();
+			expect(status.checkOutput).to.equal('Heroku log drains are misconfigured: log drain host parameter is not set');
+			expect(status.ok).to.be.false;
+		});
+
+	});
+
+	describe('when the app log drain has no channel query parameter', () => {
+
+		beforeEach(done => {
+			mockValidResponse.json.resolves([
+				{
+					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?sourcetype=heroku&source=mock-system-code&host=mock-host'
+				}
+			]);
+			check.start();
+			setTimeout(done);
+		});
+
+		it('it sets the check properties to indicate failure', () => {
+			const status = check.getStatus();
+			expect(status.checkOutput).to.equal('Heroku log drains are misconfigured: log drain channel parameter is not set');
+			expect(status.ok).to.be.false;
+		});
+
+	});
+
+	describe('when the check has no Heroku details passed as options', () => {
+
+		beforeEach(() => {
+			check = new Check({
+				id: 'mock-id',
+				name: 'mock-name'
+			});
+		});
+	
+		afterEach(() => {
+			process.env = backupEnv;
+			check.stop();
+			sinon.resetHistory();
+		});
+	
+		it('defaults them to the matching environment variables', () => {
+			expect(check.herokuAuthToken).to.equal('mock-env-auth-token');
+			expect(check.herokuAppId).to.equal('mock-env-app-id');
+		});
+
+	});
+
+	describe('when there is no Heroku auth token provided', () => {
+
+		beforeEach(done => {
+			check.herokuAuthToken = undefined;
+			check.start();
+			setTimeout(done);
+		});
+
+		it('it sets the check properties to indicate failure', () => {
+			const status = check.getStatus();
+			expect(status.checkOutput).to.equal('Heroku log drain configuration check failed to fetch data: A Heroku auth token is required to run this check. `HEROKU_AUTH_TOKEN` env var was missing');
+			expect(status.ok).to.be.false;
+		});
+
+	});
+
+	describe('when there is no Heroku app ID provided', () => {
+
+		beforeEach(done => {
+			check.herokuAppId = undefined;
+			check.start();
+			setTimeout(done);
+		});
+
+		it('it sets the check properties to indicate failure', () => {
+			const status = check.getStatus();
+			expect(status.checkOutput).to.equal('Heroku log drain configuration check failed to fetch data: A Heroku app ID is required to run this check. `HEROKU_APP_ID` env var was missing');
+			expect(status.ok).to.be.false;
+		});
+
+	});
+
+});
+
+


### PR DESCRIPTION
This adds a new check type which can validate that a Heroku app has a
valid log drain configured. We're validating against the configuration
[documented here](https://tech.in.ft.com/tech-topics/logging/splunk/logging-from-heroku#configuration).

We'll enable this check by default in n-express _if_ the app has the
latest dependencies and the migration environment flag.

One potentially contentious decision is use of the `HEROKU_APP_ID`
environment variable. Not all of our apps have this, and we'll need the
value in Heroku to be set to the _specific_ app so different per region.
I believe the ones that have this value are using this Heroku beta?
https://devcenter.heroku.com/articles/dyno-metadata

We have two options to resolve this:

1. We enable this beta for all our apps

2. We attempt to _guess_ the app name in n-express based on the `REGION`
   and `SYSTEM_CODE` environment variables, but this relies on apps
   using our established conventions consistently.

---

**edit:** looks like we already advise that we enable this beta feature [when
an app is created](https://github.com/Financial-Times/next/wiki/Creating-New-Apps#enabling-heroku-review-apps). So I think we go with option 1. We'll be able to tell if the
beta isn't enabled because the check will fail. I'm gonna update the error
message to be clear about this.

Relates-To: FTDCS-218