### PR TITLE
Remove n-raven

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "@financial-times/n-logger": "^10.2.0",
-        "@financial-times/n-raven": "^6.2.0",
         "aws-sdk": "^2.6.10",
         "fetchres": "^1.5.1",
         "moment": "^2.29.4",
@@ -583,20 +582,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@financial-times/n-raven": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-raven/-/n-raven-6.2.0.tgz",
-      "integrity": "sha512-GJSrqCvlSAtd8Zqolo2UAefjxiNKwIhbaPlBghCtHa9XG2KiVF6QeBLVf3iObKLuxuk4BgIRP4Ec/so2c8vD2g==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@financial-times/n-logger": "^10.2.0",
-        "raven": "^2.3.0"
-      },
-      "engines": {
-        "node": "14.x || 16.x",
-        "npm": "7.x || 8.x"
       }
     },
     "node_modules/@financial-times/secret-squirrel": {
@@ -3152,14 +3137,6 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
-    "node_modules/charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/check-engine": {
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/check-engine/-/check-engine-1.10.1.tgz",
@@ -3676,14 +3653,6 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
-    "node_modules/cookie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha512-+IJOX0OqlHCszo2mBUq+SrEbCj6w7Kpffqx60zYbPTFaO4+yYgRjHwcZNpWvaTylDHaV7PPmBHzSecZiMhtPgw==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/core-js": {
       "version": "3.16.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.1.tgz",
@@ -3748,14 +3717,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/crypto-random-string": {
@@ -7116,21 +7077,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "dependencies": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
-      }
-    },
-    "node_modules/md5/node_modules/is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-    },
     "node_modules/mdast-util-from-markdown": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
@@ -9035,25 +8981,6 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
-      }
-    },
-    "node_modules/raven": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/raven/-/raven-2.6.4.tgz",
-      "integrity": "sha512-6PQdfC4+DQSFncowthLf+B6Hr0JpPsFBgTVYTAOq7tCmx/kR4SXbeawtPch20+3QfUcQDoJBLjWW1ybvZ4kXTw==",
-      "deprecated": "Please upgrade to @sentry/node. See the migration guide https://bit.ly/3ybOlo7",
-      "dependencies": {
-        "cookie": "0.3.1",
-        "md5": "^2.2.1",
-        "stack-trace": "0.0.10",
-        "timed-out": "4.0.1",
-        "uuid": "3.3.2"
-      },
-      "bin": {
-        "raven": "bin/raven"
-      },
-      "engines": {
-        "node": ">= 4.0.0"
       }
     },
     "node_modules/rc": {
@@ -12025,14 +11952,6 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "node_modules/timed-out": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -13481,15 +13400,6 @@
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
           "dev": true
         }
-      }
-    },
-    "@financial-times/n-raven": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-raven/-/n-raven-6.2.0.tgz",
-      "integrity": "sha512-GJSrqCvlSAtd8Zqolo2UAefjxiNKwIhbaPlBghCtHa9XG2KiVF6QeBLVf3iObKLuxuk4BgIRP4Ec/so2c8vD2g==",
-      "requires": {
-        "@financial-times/n-logger": "^10.2.0",
-        "raven": "^2.3.0"
       }
     },
     "@financial-times/secret-squirrel": {
@@ -15501,11 +15411,6 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
-    "charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA=="
-    },
     "check-engine": {
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/check-engine/-/check-engine-1.10.1.tgz",
@@ -15900,11 +15805,6 @@
         }
       }
     },
-    "cookie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha512-+IJOX0OqlHCszo2mBUq+SrEbCj6w7Kpffqx60zYbPTFaO4+yYgRjHwcZNpWvaTylDHaV7PPmBHzSecZiMhtPgw=="
-    },
     "core-js": {
       "version": "3.16.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.1.tgz",
@@ -15955,11 +15855,6 @@
           "dev": true
         }
       }
-    },
-    "crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="
     },
     "crypto-random-string": {
       "version": "2.0.0",
@@ -18614,23 +18509,6 @@
       "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
       "dev": true
     },
-    "md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "requires": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-        }
-      }
-    },
     "mdast-util-from-markdown": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
@@ -20094,18 +19972,6 @@
       "dev": true,
       "requires": {
         "safe-buffer": "^5.1.0"
-      }
-    },
-    "raven": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/raven/-/raven-2.6.4.tgz",
-      "integrity": "sha512-6PQdfC4+DQSFncowthLf+B6Hr0JpPsFBgTVYTAOq7tCmx/kR4SXbeawtPch20+3QfUcQDoJBLjWW1ybvZ4kXTw==",
-      "requires": {
-        "cookie": "0.3.1",
-        "md5": "^2.2.1",
-        "stack-trace": "0.0.10",
-        "timed-out": "4.0.1",
-        "uuid": "3.3.2"
       }
     },
     "rc": {
@@ -22475,11 +22341,6 @@
           }
         }
       }
-    },
-    "timed-out": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA=="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   },
   "dependencies": {
     "@financial-times/n-logger": "^10.2.0",
-    "@financial-times/n-raven": "^6.2.0",
     "aws-sdk": "^2.6.10",
     "fetchres": "^1.5.1",
     "moment": "^2.29.4",

--- a/src/checks/check.js
+++ b/src/checks/check.js
@@ -2,7 +2,6 @@
 const status = require('./status');
 const ms = require('ms');
 const logger = require('@financial-times/n-logger').default;
-const raven = require('@financial-times/n-raven');
 
 const isOfficeHoursNow = () => {
 	const date = new Date();
@@ -57,7 +56,6 @@ an init method returning a Promise`)
 			await this.tick()
 		} catch(err){
 			logger.error({ event: 'FAILED_HEALTHCHECK_TICK', name: this.name }, err)
-			raven.captureError(err);
 			this.status = status.ERRORED;
 			this.checkOutput = 'Healthcheck failed to execute';
 		}


### PR DESCRIPTION
The use of n-raven in this library is causing us some issues rolling out
log drains. As part of the move to log drains we want to consistently
log errors which crashed the application and we're having to do this
work in n-raven.

While n-raven is included in both n-health and n-express, it's easy for
the versions to get out of sync. If this happens then the Sentry Raven
client is installed twice, which (because we're relying on a singleton)
will actually remove any custom unhandled exception handling code and
revert to the default Sentry handler with no error logging.

This is really bad and it could happen quite easily without anyone
knowing.

We decided that the best approach would be to remove Sentry logging from
n-health entirely and rely only on the errors we log to Splunk. A later
n-health PR will introduce Reliability Kit's error logging which will
improve things further.

This PR will result in a new major version of n-health, because we think
logging to Sentry forms part of the public API and it should be a
concious decision for teams to remove it.

Resolves [FTDCS-252](https://financialtimes.atlassian.net/browse/FTDCS-252).

---

**Note:** many of our apps _also_ include n-raven as a dependency, which
has a chance to cause issues. For now we're going to resolve this as
part of the log drain roll-out and setting the new minimum version of
n-raven to the one that includes the logging work in [this PR](https://github.com/Financial-Times/n-raven/pull/95).