### PR TITLE
Remove Heroku log drain sourcetype search param check

### DIFF
--- a/src/checks/herokuLogDrain.check.js
+++ b/src/checks/herokuLogDrain.check.js
@@ -88,10 +88,6 @@ class HerokuLogDrainCheck extends Check {
 			throw new Error('log drain source parameter is not set to the application system code');
 		}
 
-		if (parsedUrl.searchParams.get('sourcetype') !== 'heroku') {
-			throw new Error('log drain sourcetype parameter is not set to "heroku"');
-		}
-
 		if (!parsedUrl.searchParams.get('host')) {
 			throw new Error('log drain host parameter is not set');
 		}

--- a/test/herokuLogDrain.check.spec.js
+++ b/test/herokuLogDrain.check.spec.js
@@ -11,7 +11,7 @@ const mockValidResponse = {
 	ok: true,
 	json: sinon.stub().resolves([
 		{
-			url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?sourcetype=heroku&source=mock-system-code&host=mock-host&channel=mock-channel'
+			url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?source=mock-system-code&host=mock-host&channel=mock-channel'
 		}
 	])
 };
@@ -194,7 +194,7 @@ describe.only('Heroku Log Drain Check', () => {
 		beforeEach(done => {
 			mockValidResponse.json.resolves([
 				{
-					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?sourcetype=heroku&host=mock-host&channel=mock-channel'
+					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?host=mock-host&channel=mock-channel'
 				}
 			]);
 			check.start();
@@ -214,7 +214,7 @@ describe.only('Heroku Log Drain Check', () => {
 		beforeEach(done => {
 			mockValidResponse.json.resolves([
 				{
-					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?sourcetype=heroku&source=invalid&host=mock-host&channel=mock-channel'
+					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?source=invalid&host=mock-host&channel=mock-channel'
 				}
 			]);
 			check.start();
@@ -229,32 +229,12 @@ describe.only('Heroku Log Drain Check', () => {
 
 	});
 
-	describe('when the app log drain has an invalid sourcetype query parameter', () => {
-
-		beforeEach(done => {
-			mockValidResponse.json.resolves([
-				{
-					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?sourcetype=invalid&source=mock-system-code&host=mock-host&channel=mock-channel'
-				}
-			]);
-			check.start();
-			setTimeout(done);
-		});
-
-		it('it sets the check properties to indicate failure', () => {
-			const status = check.getStatus();
-			expect(status.checkOutput).to.equal('Heroku log drains are misconfigured: log drain sourcetype parameter is not set to "heroku"');
-			expect(status.ok).to.be.false;
-		});
-
-	});
-
 	describe('when the app log drain has no host query parameter', () => {
 
 		beforeEach(done => {
 			mockValidResponse.json.resolves([
 				{
-					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?sourcetype=heroku&source=mock-system-code&channel=mock-channel'
+					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?source=mock-system-code&channel=mock-channel'
 				}
 			]);
 			check.start();
@@ -274,7 +254,7 @@ describe.only('Heroku Log Drain Check', () => {
 		beforeEach(done => {
 			mockValidResponse.json.resolves([
 				{
-					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?sourcetype=heroku&source=mock-system-code&host=mock-host'
+					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?source=mock-system-code&host=mock-host'
 				}
 			]);
 			check.start();


### PR DESCRIPTION
FTDCS-257

Jira card: https://financialtimes.atlassian.net/jira/software/c/projects/FTDCS/boards/1426?modal=detail&selectedIssue=FTDCS-257

[Tech Hub: Logging to Splunk from Heroku](https://tech.in.ft.com/tech-topics/logging/splunk/logging-from-heroku#configuration) has recently changed the command (via this [`tech-hub` PR](https://github.com/Financial-Times/tech-hub/pull/742/files#diff-acb03fb0bb145aa15ed23cbd115db7496e1de8426491400ae0582104675bd834)) to configure to log drains.

**From:**
`$ heroku drains:add 'https://x:$SPLUNK_HEC_TOKEN@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?source=$SYSTEM_CODE&sourcetype=heroku&host=$HEROKU_APP_URL&channel=$SPLUNK_CHANNEL_ID' -a $HEROKU_APP_NAME`

**To:**
`$ heroku drains:add 'https://x:$SPLUNK_HEC_TOKEN@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?source=$SYSTEM_CODE&host=$HEROKU_APP_URL&channel=$SPLUNK_CHANNEL_ID' -a $HEROKU_APP_NAME`

i.e. `sourcetype=heroku` was removed

Any subsequent Heroku log drains that are configured going forwards do not require `sourcetype` in their params and so we should not be failing the healthcheck based on its absence (or indeed it matching `'heroku'`), which will be expected.

#### Release version
As this is reducing the stringency of the healthchecks in a backwards-compatible manner, I feel this should be a patch release.