### PR TITLE
Modify Heroku log drain check to ensure absence of sourcetype param

### DIFF
--- a/src/checks/herokuLogDrain.check.js
+++ b/src/checks/herokuLogDrain.check.js
@@ -88,8 +88,8 @@ class HerokuLogDrainCheck extends Check {
 			throw new Error('log drain source parameter is not set to the application system code');
 		}
 
-		if (parsedUrl.searchParams.get('sourcetype') !== 'heroku') {
-			throw new Error('log drain sourcetype parameter is not set to "heroku"');
+		if (parsedUrl.searchParams.get('sourcetype')) {
+			throw new Error('log drain sourcetype parameter is present; sourcetype should instead be specified on the HEC (HTTP Event Collector) token');
 		}
 
 		if (!parsedUrl.searchParams.get('host')) {

--- a/test/herokuLogDrain.check.spec.js
+++ b/test/herokuLogDrain.check.spec.js
@@ -11,7 +11,7 @@ const mockValidResponse = {
 	ok: true,
 	json: sinon.stub().resolves([
 		{
-			url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?sourcetype=heroku&source=mock-system-code&host=mock-host&channel=mock-channel'
+			url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?source=mock-system-code&host=mock-host&channel=mock-channel'
 		}
 	])
 };
@@ -194,7 +194,7 @@ describe.only('Heroku Log Drain Check', () => {
 		beforeEach(done => {
 			mockValidResponse.json.resolves([
 				{
-					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?sourcetype=heroku&host=mock-host&channel=mock-channel'
+					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?host=mock-host&channel=mock-channel'
 				}
 			]);
 			check.start();
@@ -214,7 +214,7 @@ describe.only('Heroku Log Drain Check', () => {
 		beforeEach(done => {
 			mockValidResponse.json.resolves([
 				{
-					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?sourcetype=heroku&source=invalid&host=mock-host&channel=mock-channel'
+					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?source=invalid&host=mock-host&channel=mock-channel'
 				}
 			]);
 			check.start();
@@ -229,12 +229,12 @@ describe.only('Heroku Log Drain Check', () => {
 
 	});
 
-	describe('when the app log drain has an invalid sourcetype query parameter', () => {
+	describe('when the app log drain has a sourcetype query parameter (sourcetype should instead be specified on the HEC (HTTP Event Collector) token)', () => {
 
 		beforeEach(done => {
 			mockValidResponse.json.resolves([
 				{
-					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?sourcetype=invalid&source=mock-system-code&host=mock-host&channel=mock-channel'
+					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?sourcetype=mock-sourcetype&source=mock-system-code&host=mock-host&channel=mock-channel'
 				}
 			]);
 			check.start();
@@ -243,7 +243,7 @@ describe.only('Heroku Log Drain Check', () => {
 
 		it('it sets the check properties to indicate failure', () => {
 			const status = check.getStatus();
-			expect(status.checkOutput).to.equal('Heroku log drains are misconfigured: log drain sourcetype parameter is not set to "heroku"');
+			expect(status.checkOutput).to.equal('Heroku log drains are misconfigured: log drain sourcetype parameter is present; sourcetype should instead be specified on the HEC (HTTP Event Collector) token');
 			expect(status.ok).to.be.false;
 		});
 
@@ -254,7 +254,7 @@ describe.only('Heroku Log Drain Check', () => {
 		beforeEach(done => {
 			mockValidResponse.json.resolves([
 				{
-					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?sourcetype=heroku&source=mock-system-code&channel=mock-channel'
+					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?source=mock-system-code&channel=mock-channel'
 				}
 			]);
 			check.start();
@@ -274,7 +274,7 @@ describe.only('Heroku Log Drain Check', () => {
 		beforeEach(done => {
 			mockValidResponse.json.resolves([
 				{
-					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?sourcetype=heroku&source=mock-system-code&host=mock-host'
+					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?source=mock-system-code&host=mock-host'
 				}
 			]);
 			check.start();


### PR DESCRIPTION
FTDCS-257

Jira card: https://financialtimes.atlassian.net/jira/software/c/projects/FTDCS/boards/1426?modal=detail&selectedIssue=FTDCS-257

This PR supersedes https://github.com/Financial-Times/n-health/pull/200

[Tech Hub: Logging to Splunk from Heroku](https://tech.in.ft.com/tech-topics/logging/splunk/logging-from-heroku#configuration) has recently changed the command (via this [`tech-hub` PR](https://github.com/Financial-Times/tech-hub/pull/742/files#diff-acb03fb0bb145aa15ed23cbd115db7496e1de8426491400ae0582104675bd834)) to configure to log drains.

**From:**
`$ heroku drains:add 'https://x:$SPLUNK_HEC_TOKEN@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?source=$SYSTEM_CODE&sourcetype=heroku&host=$HEROKU_APP_URL&channel=$SPLUNK_CHANNEL_ID' -a $HEROKU_APP_NAME`

**To:**
`$ heroku drains:add 'https://x:$SPLUNK_HEC_TOKEN@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?source=$SYSTEM_CODE&host=$HEROKU_APP_URL&channel=$SPLUNK_CHANNEL_ID' -a $HEROKU_APP_NAME`

i.e. `sourcetype=heroku` was removed

Any subsequent Heroku log drains that are configured going forwards do not require `sourcetype` in their params and so we should not be failing the healthcheck based on its absence (or indeed it matching `'heroku'`), which will be expected.

However, following a [Slack conversation](https://financialtimes.slack.com/archives/C02BD0D8D4Z/p1659957362183249) with @sjparkinson, it is best practice to omit the `sourcetype` from the params and instead specify it on the HEC (HTTP Event Collector) token. This is so that in future if we need to change the `sourcetype` name for whatever reason it will be harder to do if it is hardcoded everywhere.

Therefore, the check has been modified to alert if the `sourcetype` param is present. Any apps that have already been configured to use the `sourcetype` param will be required to re-configure its Heroku log drain to ensure the check remains healthy.

### Release version
This is not a breaking change in that no code changes are required in the consuming app, although it could cause one of the consuming app's healthchecks to fail if its Heroku log drain is not reconfigured, so in that way it could be argued to be a breaking change… 🤔 

Though that in itself is not broken code as everything will still run as it needs to.

Ultimately, it is changed functionality in a backwards compatible manner, so I would suggest a **minor** release.