### PR TITLE
Fix unusable Markdown in Heroku log drain check panic guide text

### DIFF
--- a/src/checks/herokuLogDrain.check.js
+++ b/src/checks/herokuLogDrain.check.js
@@ -3,7 +3,7 @@ const logger = require('@financial-times/n-logger').default;
 const Check = require('./check');
 const status = require('./status');
 
-const defaultPanicGuide = '[Check whether the app has been migrated to use log drains](https://financialtimes.atlassian.net/wiki/spaces/DS/pages/7883555001/Migrating+an+app+to+Heroku+log+drains). If it has been migrated then the log drain is either misconfigured or missing, follow the migration guide to correct this.';
+const defaultPanicGuide = 'Check whether the app has been migrated to use log drains. If it has been migrated then the log drain is either misconfigured or missing, and can be corrected by following the migration guide (https://financialtimes.atlassian.net/wiki/spaces/DS/pages/7883555001/Migrating+an+app+to+Heroku+log+drains).';
 const defaultTechnicalSummary = 'Uses the Heroku API to fetch Heroku log drains for the application and verify that they\'re configured to drain into the correct Splunk endpoint.';
 const defaultBusinessImpact = 'Logs may not be captured in Splunk for this application. It may not be possible to debug other issues while log drains are not configured.';
 const defaultSeverity = 2;

--- a/test/herokuLogDrain.check.spec.js
+++ b/test/herokuLogDrain.check.spec.js
@@ -63,7 +63,7 @@ describe.only('Heroku Log Drain Check', () => {
 		expect(status.severity).to.equal(2);
 		expect(status.businessImpact).to.equal('Logs may not be captured in Splunk for this application. It may not be possible to debug other issues while log drains are not configured.');
 		expect(status.technicalSummary).to.equal('Uses the Heroku API to fetch Heroku log drains for the application and verify that they\'re configured to drain into the correct Splunk endpoint.');
-		expect(status.panicGuide).to.equal('[Check whether the app has been migrated to use log drains](https://financialtimes.atlassian.net/wiki/spaces/DS/pages/7883555001/Migrating+an+app+to+Heroku+log+drains). If it has been migrated then the log drain is either misconfigured or missing, follow the migration guide to correct this.');
+		expect(status.panicGuide).to.equal('Check whether the app has been migrated to use log drains. If it has been migrated then the log drain is either misconfigured or missing, and can be corrected by following the migration guide (https://financialtimes.atlassian.net/wiki/spaces/DS/pages/7883555001/Migrating+an+app+to+Heroku+log+drains).');
 	});
 
 	describe('when the app has a valid Heroku log drain configured', () => {


### PR DESCRIPTION
This PR amends the panic guide text in the Heroku log drain check so that it does not use Markdown which is not supported in the Heimdall GUI, e.g.

https://heimdall.ftops.tech/system?code=next-houston

<img width="1237" alt="Screenshot 2022-08-11 at 13 21 59" src="https://user-images.githubusercontent.com/10484515/184132523-4e79f36f-15e0-4754-9ddd-60e2ce5fd1a1.png">