### PR TITLE
Add Heroku log drain host format check

### DIFF
--- a/src/checks/herokuLogDrain.check.js
+++ b/src/checks/herokuLogDrain.check.js
@@ -8,6 +8,10 @@ const defaultTechnicalSummary = 'Uses the Heroku API to fetch Heroku log drains 
 const defaultBusinessImpact = 'Logs may not be captured in Splunk for this application. It may not be possible to debug other issues while log drains are not configured.';
 const defaultSeverity = 2;
 
+// Required format is the Heroku app URL exlcuding the protocol and path
+// e.g. ft-next-ads-api-eu.herokuapp.com, not https:/ft-next-ads-api-eu.herokuapp.com
+const HEROKU_LOG_DRAIN_HOST_FORMAT_REGEX = new RegExp(/^(?!http:\/)[a-z\-]*\.herokuapp\.com$/);
+
 class HerokuLogDrainCheck extends Check {
 
 	constructor({
@@ -92,8 +96,11 @@ class HerokuLogDrainCheck extends Check {
 			throw new Error('log drain sourcetype parameter is present; sourcetype should instead be specified on the HEC (HTTP Event Collector) token');
 		}
 
-		if (!parsedUrl.searchParams.get('host')) {
-			throw new Error('log drain host parameter is not set');
+		if (
+			!parsedUrl.searchParams.get('host') ||
+			!HEROKU_LOG_DRAIN_HOST_FORMAT_REGEX.test(parsedUrl.searchParams.get('host'))
+		) {
+			throw new Error('log drain host parameter is not set or is in an incorrect format');
 		}
 
 		if (!parsedUrl.searchParams.get('channel')) {

--- a/src/checks/herokuLogDrain.check.js
+++ b/src/checks/herokuLogDrain.check.js
@@ -10,7 +10,7 @@ const defaultSeverity = 2;
 
 // Required format is the Heroku app URL exlcuding the protocol and path
 // e.g. ft-next-ads-api-eu.herokuapp.com, not https:/ft-next-ads-api-eu.herokuapp.com
-const HEROKU_LOG_DRAIN_HOST_FORMAT_REGEX = new RegExp(/^(?!http:\/)[a-z\-]*\.herokuapp\.com$/);
+const HEROKU_LOG_DRAIN_HOST_FORMAT_REGEX = /^[a-z0-9-]+\.herokuapp\.com$/;
 
 class HerokuLogDrainCheck extends Check {
 

--- a/test/herokuLogDrain.check.spec.js
+++ b/test/herokuLogDrain.check.spec.js
@@ -11,7 +11,7 @@ const mockValidResponse = {
 	ok: true,
 	json: sinon.stub().resolves([
 		{
-			url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?source=mock-system-code&host=mock-host.herokuapp.com&channel=mock-channel'
+			url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?source=mock-system-code&host=mock-valid-app-name.herokuapp.com&channel=mock-channel'
 		}
 	])
 };
@@ -44,7 +44,8 @@ describe.only('Heroku Log Drain Check', () => {
 			id: 'mock-id',
 			name: 'mock-name',
 			herokuAuthToken: 'mock-auth-token',
-			herokuAppId: 'mock-valid-app-id'
+			herokuAppId: 'mock-valid-app-id',
+			herokuAppName: 'mock-valid-app-name',
 		});
 	});
 
@@ -194,7 +195,7 @@ describe.only('Heroku Log Drain Check', () => {
 		beforeEach(done => {
 			mockValidResponse.json.resolves([
 				{
-					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?host=mock-host.herokuapp.com&channel=mock-channel'
+					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?host=mock-valid-app-name.herokuapp.com&channel=mock-channel'
 				}
 			]);
 			check.start();
@@ -214,7 +215,7 @@ describe.only('Heroku Log Drain Check', () => {
 		beforeEach(done => {
 			mockValidResponse.json.resolves([
 				{
-					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?source=invalid&host=mock-host.herokuapp.com&channel=mock-channel'
+					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?source=invalid&host=mock-valid-app-name.herokuapp.com&channel=mock-channel'
 				}
 			]);
 			check.start();
@@ -234,7 +235,7 @@ describe.only('Heroku Log Drain Check', () => {
 		beforeEach(done => {
 			mockValidResponse.json.resolves([
 				{
-					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?sourcetype=mock-sourcetype&source=mock-system-code&host=mock-host.herokuapp.com&channel=mock-channel'
+					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?sourcetype=mock-sourcetype&source=mock-system-code&host=mock-valid-app-name.herokuapp.com&channel=mock-channel'
 				}
 			]);
 			check.start();
@@ -263,7 +264,7 @@ describe.only('Heroku Log Drain Check', () => {
 
 		it('it sets the check properties to indicate failure', () => {
 			const status = check.getStatus();
-			expect(status.checkOutput).to.equal('Heroku log drains are misconfigured: log drain host parameter is not set or is in an incorrect format');
+			expect(status.checkOutput).to.equal('Heroku log drains are misconfigured: log drain host parameter is not set or is not the app\'s name (excluding protocol and path)');
 			expect(status.ok).to.be.false;
 		});
 
@@ -274,7 +275,7 @@ describe.only('Heroku Log Drain Check', () => {
 		beforeEach(done => {
 			mockValidResponse.json.resolves([
 				{
-					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?source=mock-system-code&host=https:/mock-host.herokuapp.com&channel=mock-channel'
+					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?source=mock-system-code&host=mock-invalid-app-name.herokuapp.com&channel=mock-channel'
 				}
 			]);
 			check.start();
@@ -283,7 +284,7 @@ describe.only('Heroku Log Drain Check', () => {
 
 		it('it sets the check properties to indicate failure', () => {
 			const status = check.getStatus();
-			expect(status.checkOutput).to.equal('Heroku log drains are misconfigured: log drain host parameter is not set or is in an incorrect format');
+			expect(status.checkOutput).to.equal('Heroku log drains are misconfigured: log drain host parameter is not set or is not the app\'s name (excluding protocol and path)');
 			expect(status.ok).to.be.false;
 		});
 
@@ -294,7 +295,7 @@ describe.only('Heroku Log Drain Check', () => {
 		beforeEach(done => {
 			mockValidResponse.json.resolves([
 				{
-					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?source=mock-system-code&host=mock-host.herokuapp.com'
+					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?source=mock-system-code&host=mock-valid-app-name.herokuapp.com'
 				}
 			]);
 			check.start();

--- a/test/herokuLogDrain.check.spec.js
+++ b/test/herokuLogDrain.check.spec.js
@@ -11,7 +11,7 @@ const mockValidResponse = {
 	ok: true,
 	json: sinon.stub().resolves([
 		{
-			url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?source=mock-system-code&host=mock-host&channel=mock-channel'
+			url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?source=mock-system-code&host=mock-host.herokuapp.com&channel=mock-channel'
 		}
 	])
 };
@@ -194,7 +194,7 @@ describe.only('Heroku Log Drain Check', () => {
 		beforeEach(done => {
 			mockValidResponse.json.resolves([
 				{
-					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?host=mock-host&channel=mock-channel'
+					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?host=mock-host.herokuapp.com&channel=mock-channel'
 				}
 			]);
 			check.start();
@@ -214,7 +214,7 @@ describe.only('Heroku Log Drain Check', () => {
 		beforeEach(done => {
 			mockValidResponse.json.resolves([
 				{
-					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?source=invalid&host=mock-host&channel=mock-channel'
+					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?source=invalid&host=mock-host.herokuapp.com&channel=mock-channel'
 				}
 			]);
 			check.start();
@@ -234,7 +234,7 @@ describe.only('Heroku Log Drain Check', () => {
 		beforeEach(done => {
 			mockValidResponse.json.resolves([
 				{
-					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?sourcetype=mock-sourcetype&source=mock-system-code&host=mock-host&channel=mock-channel'
+					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?sourcetype=mock-sourcetype&source=mock-system-code&host=mock-host.herokuapp.com&channel=mock-channel'
 				}
 			]);
 			check.start();
@@ -263,7 +263,27 @@ describe.only('Heroku Log Drain Check', () => {
 
 		it('it sets the check properties to indicate failure', () => {
 			const status = check.getStatus();
-			expect(status.checkOutput).to.equal('Heroku log drains are misconfigured: log drain host parameter is not set');
+			expect(status.checkOutput).to.equal('Heroku log drains are misconfigured: log drain host parameter is not set or is in an incorrect format');
+			expect(status.ok).to.be.false;
+		});
+
+	});
+
+	describe('when the app log drain has a host query parameter in the incorrect format', () => {
+
+		beforeEach(done => {
+			mockValidResponse.json.resolves([
+				{
+					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?source=mock-system-code&host=https:/mock-host.herokuapp.com&channel=mock-channel'
+				}
+			]);
+			check.start();
+			setTimeout(done);
+		});
+
+		it('it sets the check properties to indicate failure', () => {
+			const status = check.getStatus();
+			expect(status.checkOutput).to.equal('Heroku log drains are misconfigured: log drain host parameter is not set or is in an incorrect format');
 			expect(status.ok).to.be.false;
 		});
 
@@ -274,7 +294,7 @@ describe.only('Heroku Log Drain Check', () => {
 		beforeEach(done => {
 			mockValidResponse.json.resolves([
 				{
-					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?source=mock-system-code&host=mock-host'
+					url: 'https://x:mock-splunk-token@http-inputs-financialtimes.splunkcloud.com/services/collector/raw?source=mock-system-code&host=mock-host.herokuapp.com'
 				}
 			]);
 			check.start();


### PR DESCRIPTION
FTDCS-299

Jira card: https://financialtimes.atlassian.net/jira/software/c/projects/FTDCS/boards/1426?modal=detail&selectedIssue=FTDCS-299

Ref. [Slack chat](https://financialtimes.slack.com/archives/C02B89GEQHF/p1661528764824409) in which it was identified that the Heroku log drains for next-ads-api incorrectly prefixed its `host` param value with `https:/` - Step 2.3 of the [migration guide](https://financialtimes.atlassian.net/wiki/spaces/DS/pages/7883555001/Migrating+an+app+to+Heroku+log+drains#Step-2.3) states that the `host` param value should be:

> The Heroku app URL excluding the protocol and path (e.g. ft-next-article-eu.herokuapp.com)

![Screenshot 2022-08-30 at 12 25 56](https://user-images.githubusercontent.com/10484515/187424939-9301c04f-b0b6-40e8-a58f-255a6a83d318.png)

#### References:
- [Stack Overflow: javascript regular expression to not match a word](https://stackoverflow.com/questions/6449131/javascript-regular-expression-to-not-match-a-word#answer-15508679)
- [Regular Expressions 101](https://regex101.com) (regular expressions tester)