### PR TITLE
Increase interval between Heroku log drain health checks

### DIFF
--- a/src/checks/herokuLogDrain.check.js
+++ b/src/checks/herokuLogDrain.check.js
@@ -3,10 +3,13 @@ const logger = require('@financial-times/n-logger').default;
 const Check = require('./check');
 const status = require('./status');
 
+const ONE_DAY_IN_MILLISECONDS = 1000 * 60 * 60 * 24;
+
 const defaultPanicGuide = 'Check whether the app has been migrated to use log drains. If it has been migrated then the log drain is either misconfigured or missing, and can be corrected by following the migration guide (https://financialtimes.atlassian.net/wiki/spaces/DS/pages/7883555001/Migrating+an+app+to+Heroku+log+drains).';
 const defaultTechnicalSummary = 'Uses the Heroku API to fetch Heroku log drains for the application and verify that they\'re configured to drain into the correct Splunk endpoint.';
 const defaultBusinessImpact = 'Logs may not be captured in Splunk for this application. It may not be possible to debug other issues while log drains are not configured.';
 const defaultSeverity = 2;
+const defaultInterval = ONE_DAY_IN_MILLISECONDS;
 
 class HerokuLogDrainCheck extends Check {
 
@@ -15,6 +18,7 @@ class HerokuLogDrainCheck extends Check {
 		technicalSummary = defaultTechnicalSummary,
 		businessImpact = defaultBusinessImpact,
 		severity = defaultSeverity,
+		interval = defaultInterval,
 		herokuAuthToken = process.env.HEROKU_AUTH_TOKEN,
 		herokuAppId = process.env.HEROKU_APP_ID,
 		herokuAppName = process.env.HEROKU_APP_NAME,


### PR DESCRIPTION
The [README](https://github.com/Financial-Times/n-health) for this repo says that the options for check objects include:

> `interval`: time between checks in milliseconds or any string compatible with [ms](https://www.npmjs.com/package/ms) [default: 1minute]

We are currently experiencing the below error for several apps:
> "Heroku log drain configuration check failed to fetch data: heroku responded with a 429 status code"

It seems unnecessary for this to be checked at one minute intervals because it is not a condition that will change will a high amount of regularity and given the effect it is having on contributing to reaching our Heroku API key limit, it seems judicious to reduce its impact.

Perhaps one day intervals is too extreme and happy to take a steer on what might be a more suitable interval.