### PR TITLE
add overrides for weekend on graphiteWorking check

### DIFF
--- a/src/checks/graphiteWorking.check.js
+++ b/src/checks/graphiteWorking.check.js
@@ -6,134 +6,134 @@ const fetchres = require('fetchres');
 const logEventPrefix = 'GRAPHITE_WORKING_CHECK';
 
 function badJSON(message, json) {
-    const err = new Error(message);
-    log.error({ event: `${logEventPrefix}_BAD_JSON` }, err);
-    throw err;
+	const err = new Error(message);
+	log.error({ event: `${logEventPrefix}_BAD_JSON` }, err);
+	throw err;
 }
 
 
 class GraphiteWorkingCheck extends Check {
-    constructor (options) {
-        options.technicalSummary = options.technicalSummary || 'There has been no metric data for a sustained period of time';
-        options.panicGuide = options.panicGuide || 'Check this is up and running. Check this has been able to send metrics to Graphite (see Heroku and Splunk logs). Check Graphite has not been dropping metric data.';
+	constructor (options) {
+		options.technicalSummary = options.technicalSummary || 'There has been no metric data for a sustained period of time';
+		options.panicGuide = options.panicGuide || 'Check this is up and running. Check this has been able to send metrics to Graphite (see Heroku and Splunk logs). Check Graphite has not been dropping metric data.';
 
-        super(options);
+		super(options);
 
-        this.ftGraphiteKey = process.env.FT_GRAPHITE_KEY;
-        if (!this.ftGraphiteKey) {
-            throw new Error('You must set FT_GRAPHITE_KEY environment variable');
-        }
+		this.ftGraphiteKey = process.env.FT_GRAPHITE_KEY;
+		if (!this.ftGraphiteKey) {
+			throw new Error('You must set FT_GRAPHITE_KEY environment variable');
+		}
 
-        this.metric = options.metric || options.key;
-        if (!this.metric) {
-            throw new Error(`You must pass in a metric for the "${options.name}" check - e.g., "next.heroku.article.*.express.start"`);
-        }
+		this.metric = options.metric || options.key;
+		if (!this.metric) {
+			throw new Error(`You must pass in a metric for the "${options.name}" check - e.g., "next.heroku.article.*.express.start"`);
+		}
 
-        this.time = options.time || '-5minutes';
-        this.checkOutput = "This check has not yet run";
-        this.override = options.override;
-        this.initialState = {};
-        this.isOverride = false;
-        //store the initial status of the properties that are going to be override
-        if(this.override){
-            for(let conceptOverride in  this.override){
-				for(let key in this.override[conceptOverride]){
+		this.time = options.time || '-5minutes';
+		this.checkOutput = "This check has not yet run";
+		this.override = options.override;
+		this.initialState = {};
+		this.isOverride = false;
+		//store the initial status of the properties that are going to be override
+		if (this.override) {
+			for (let conceptOverride in this.override) {
+				for (let key in this.override[conceptOverride]) {
 					this.initialState[key] = this[key];
 				}
-            }
-        }
-        
-    }
+			}
+		}
+
+	}
 	get fromTime() {
 		return this.time;
 	}
-    getUrl(){
-        return encodeURI(`https://graphitev2-api.ft.com/render/?target=${this.metric}&from=${this.fromTime}&format=json`);
-    }
+	getUrl() {
+		return encodeURI(`https://graphitev2-api.ft.com/render/?target=${this.metric}&from=${this.fromTime}&format=json`);
+	}
 
-    hookOverrides(){
-        if(!this.override)
-        return;
-        if(this.override.weekend){
-            if(this.isWeekend() && !this.isOverride){
-                this.applyOverrides(this.override.weekend);
-            }
-            else if(this.isOverride){
-                this.setInitialState();
-            }
-        }
-    }
+	hookOverrides() {
+		if (!this.override)
+			return;
+		if (this.override.weekend) {
+			if (this.isWeekend() && !this.isOverride) {
+				this.applyOverrides(this.override.weekend);
+			}
+			else if (this.isOverride) {
+				this.setInitialState();
+			}
+		}
+	}
 
-    setInitialState(){
-        this.applyOverrides(this.initialState);
-        this.isOverride = false;
-    }
+	setInitialState() {
+		this.applyOverrides(this.initialState);
+		this.isOverride = false;
+	}
 
-    applyOverrides(overrides){
-        if(!overrides)
-        return;
-        Object.keys(overrides).forEach((key) => {
-            this[key] = overrides[key];
-        });
-        this.isOverride = true;
-    }
+	applyOverrides(overrides) {
+		if (!overrides)
+			return;
+		Object.keys(overrides).forEach((key) => {
+			this[key] = overrides[key];
+		});
+		this.isOverride = true;
+	}
 	isWeekend() {
 		const date = new Date();
 		const day = date.getDay(); // Sunday is 0, Saturday is 6
 		return day === 0 || day === 6;
 	}
 
-    async tick() {
-        try {
-            this.hookOverrides();
-            const json = await fetch(this.getUrl(), {
-                headers: { key: this.ftGraphiteKey }
-            }).then(fetchres.json);
+	async tick() {
+		try {
+			this.hookOverrides();
+			const json = await fetch(this.getUrl(), {
+				headers: { key: this.ftGraphiteKey }
+			}).then(fetchres.json);
 
-            if(!json.length) {
-                badJSON('returned JSON should be an array', json);
-            }
+			if(!json.length) {
+				badJSON('returned JSON should be an array', json);
+			}
 
-            if(!json[0].datapoints) {
-                badJSON('No datapoints property', json);
-            }
+			if(!json[0].datapoints) {
+				badJSON('No datapoints property', json);
+			}
 
-            if(json[0].datapoints.length < 1) {
-                badJSON('Expected at least one datapoint', json);
-            }
+			if(json[0].datapoints.length < 1) {
+				badJSON('Expected at least one datapoint', json);
+			}
 
-            const simplifiedResults = json.map(result => {
-                let nullsForHowManySeconds;
+			const simplifiedResults = json.map(result => {
+				let nullsForHowManySeconds;
 
-                if (result.datapoints.every(datapoint => datapoint[0] === null)) {
-                    nullsForHowManySeconds = Infinity;
-                } else {
-                    // This sums the number of seconds since the last non-null result at the tail of the list of metrics.
-                            nullsForHowManySeconds = result.datapoints
-                                    .map((datapoint, index, array) => [datapoint[0], index > 0 ? datapoint[1] - array[index - 1][1]  : 0])
-                                    .reduce((xs, datapoint) => datapoint[0] === null ? xs + datapoint[1] : 0, 0);
-                        }
+				if (result.datapoints.every(datapoint => datapoint[0] === null)) {
+					nullsForHowManySeconds = Infinity;
+				} else {
+					// This sums the number of seconds since the last non-null result at the tail of the list of metrics.
+					nullsForHowManySeconds = result.datapoints
+					.map((datapoint, index, array) => [datapoint[0], index > 0 ? datapoint[1] - array[index - 1][1]  : 0])
+					.reduce((xs, datapoint) => datapoint[0] === null ? xs + datapoint[1] : 0, 0);
+			}
 
-                const simplifiedResult = { target: result.target, nullsForHowManySeconds };
-                log.info({ event: `${logEventPrefix}_NULLS_FOR_HOW_LONG` }, simplifiedResult);
-                return simplifiedResult;
-            });
+				const simplifiedResult = { target: result.target, nullsForHowManySeconds };
+				log.info({ event: `${logEventPrefix}_NULLS_FOR_HOW_LONG` }, simplifiedResult);
+				return simplifiedResult;
+			});
 
-            const failedResults = simplifiedResults.filter(r => r.nullsForHowManySeconds >= 180);
+			const failedResults = simplifiedResults.filter(r => r.nullsForHowManySeconds >= 180);
 
-            if (failedResults.length === 0) {
-                this.status = status.PASSED;
-                this.checkOutput =`${this.metric} has data`;
-            } else {
-                this.status = status.FAILED;
-                this.checkOutput = failedResults.map(r => `${r.target} has been null for ${Math.round(r.nullsForHowManySeconds / 60)} minutes.`).join(' ');
-            }
-        } catch(err) {
-            log.error({ event: `${logEventPrefix}_ERROR`, url: this.getUrl() }, err);
-            this.status = status.FAILED;
-            this.checkOutput = err.toString();
-        }
-    }
+			if (failedResults.length === 0) {
+				this.status = status.PASSED;
+				this.checkOutput =`${this.metric} has data`;
+			} else {
+				this.status = status.FAILED;
+				this.checkOutput = failedResults.map(r => `${r.target} has been null for ${Math.round(r.nullsForHowManySeconds / 60)} minutes.`).join(' ');
+			}
+		} catch(err) {
+			log.error({ event: `${logEventPrefix}_ERROR`, url: this.getUrl() }, err);
+			this.status = status.FAILED;
+			this.checkOutput = err.toString();
+		}
+	}
 }
 
 module.exports = GraphiteWorkingCheck;

--- a/src/checks/graphiteWorking.check.js
+++ b/src/checks/graphiteWorking.check.js
@@ -3,88 +3,138 @@ const Check = require('./check');
 const fetch = require('node-fetch');
 const log = require('@financial-times/n-logger').default;
 const fetchres = require('fetchres');
-
 const logEventPrefix = 'GRAPHITE_WORKING_CHECK';
 
 function badJSON(message, json) {
-	const err = new Error(message);
-	log.error({ event: `${logEventPrefix}_BAD_JSON` }, err);
-	throw err;
+    const err = new Error(message);
+    log.error({ event: `${logEventPrefix}_BAD_JSON` }, err);
+    throw err;
 }
 
+
 class GraphiteWorkingCheck extends Check {
-	constructor (options) {
-		options.technicalSummary = options.technicalSummary || 'There has been no metric data for a sustained period of time';
-		options.panicGuide = options.panicGuide || 'Check this is up and running. Check this has been able to send metrics to Graphite (see Heroku and Splunk logs). Check Graphite has not been dropping metric data.';
+    constructor (options) {
+        options.technicalSummary = options.technicalSummary || 'There has been no metric data for a sustained period of time';
+        options.panicGuide = options.panicGuide || 'Check this is up and running. Check this has been able to send metrics to Graphite (see Heroku and Splunk logs). Check Graphite has not been dropping metric data.';
 
-		super(options);
+        super(options);
 
-		this.ftGraphiteKey = process.env.FT_GRAPHITE_KEY;
-		if (!this.ftGraphiteKey) {
-			throw new Error('You must set FT_GRAPHITE_KEY environment variable');
-		}
+        this.ftGraphiteKey = process.env.FT_GRAPHITE_KEY;
+        if (!this.ftGraphiteKey) {
+            throw new Error('You must set FT_GRAPHITE_KEY environment variable');
+        }
 
-		this.metric = options.metric || options.key;
-		if (!this.metric) {
-			throw new Error(`You must pass in a metric for the "${options.name}" check - e.g., "next.heroku.article.*.express.start"`);
-		}
+        this.metric = options.metric || options.key;
+        if (!this.metric) {
+            throw new Error(`You must pass in a metric for the "${options.name}" check - e.g., "next.heroku.article.*.express.start"`);
+        }
 
-		const fromTime = options.time || '-5minutes';
-		this.url = encodeURI(`https://graphitev2-api.ft.com/render/?target=${this.metric}&from=${fromTime}&format=json`);
+        this.time = options.time || '-5minutes';
+        this.checkOutput = "This check has not yet run";
+        this.override = options.override;
+        this.initialState = {};
+        this.isOverride = false;
+        //store the initial status of the properties that are going to be override
+        if(this.override){
+            for(let conceptOverride in  this.override){
+				for(let key in this.override[conceptOverride]){
+					this.initialState[key] = this[key];
+				}
+            }
+        }
+        
+    }
+	get fromTime() {
+		return this.time;
+	}
+    getUrl(){
+        return encodeURI(`https://graphitev2-api.ft.com/render/?target=${this.metric}&from=${this.fromTime}&format=json`);
+    }
 
-		this.checkOutput = "This check has not yet run";
+    hookOverrides(){
+        if(!this.override)
+        return;
+        if(this.override.weekend){
+            if(this.isWeekend() && !this.isOverride){
+                this.applyOverrides(this.override.weekend);
+            }
+            else if(this.isOverride){
+                this.setInitialState();
+            }
+        }
+    }
+
+    setInitialState(){
+        this.applyOverrides(this.initialState);
+        this.isOverride = false;
+    }
+
+    applyOverrides(overrides){
+        if(!overrides)
+        return;
+        Object.keys(overrides).forEach((key) => {
+            this[key] = overrides[key];
+        });
+        this.isOverride = true;
+    }
+	isWeekend() {
+		const date = new Date();
+		const day = date.getDay(); // Sunday is 0, Saturday is 6
+		return day === 0 || day === 6;
 	}
 
-	async tick() {
-		try {
-			const json = await fetch(this.url, {
-				headers: { key: this.ftGraphiteKey }
-			}).then(fetchres.json);
+    async tick() {
+        try {
+            this.hookOverrides();
+            const json = await fetch(this.getUrl(), {
+                headers: { key: this.ftGraphiteKey }
+            }).then(fetchres.json);
 
-			if(!json.length) {
-				badJSON('returned JSON should be an array', json);
-			}
+            if(!json.length) {
+                badJSON('returned JSON should be an array', json);
+            }
 
-			if(!json[0].datapoints) {
-				badJSON('No datapoints property', json);
-			}
+            if(!json[0].datapoints) {
+                badJSON('No datapoints property', json);
+            }
 
-			if(json[0].datapoints.length < 1) {
-				badJSON('Expected at least one datapoint', json);
-			}
+            if(json[0].datapoints.length < 1) {
+                badJSON('Expected at least one datapoint', json);
+            }
 
-			const simplifiedResults = json.map(result => {
-				let nullsForHowManySeconds;
+            const simplifiedResults = json.map(result => {
+                let nullsForHowManySeconds;
 
-				if (result.datapoints.every(datapoint => datapoint[0] === null)) {
-					nullsForHowManySeconds = Infinity;
-				} else {
-					// This sums the number of seconds since the last non-null result at the tail of the list of metrics.
-							nullsForHowManySeconds = result.datapoints
-									.map((datapoint, index, array) => [datapoint[0], index > 0 ? datapoint[1] - array[index - 1][1]  : 0])
-									.reduce((xs, datapoint) => datapoint[0] === null ? xs + datapoint[1] : 0, 0);
-						}
+                if (result.datapoints.every(datapoint => datapoint[0] === null)) {
+                    nullsForHowManySeconds = Infinity;
+                } else {
+                    // This sums the number of seconds since the last non-null result at the tail of the list of metrics.
+                            nullsForHowManySeconds = result.datapoints
+                                    .map((datapoint, index, array) => [datapoint[0], index > 0 ? datapoint[1] - array[index - 1][1]  : 0])
+                                    .reduce((xs, datapoint) => datapoint[0] === null ? xs + datapoint[1] : 0, 0);
+                        }
 
-				const simplifiedResult = { target: result.target, nullsForHowManySeconds };
-				log.info({ event: `${logEventPrefix}_NULLS_FOR_HOW_LONG` }, simplifiedResult);
-				return simplifiedResult;
-			});
+                const simplifiedResult = { target: result.target, nullsForHowManySeconds };
+                log.info({ event: `${logEventPrefix}_NULLS_FOR_HOW_LONG` }, simplifiedResult);
+                return simplifiedResult;
+            });
 
-			const failedResults = simplifiedResults.filter(r => r.nullsForHowManySeconds >= 180);
+            const failedResults = simplifiedResults.filter(r => r.nullsForHowManySeconds >= 180);
 
-			if (failedResults.length === 0) {
-				this.status = status.PASSED;
-				this.checkOutput =`${this.metric} has data`;
-			} else {
-				this.status = status.FAILED;
-				this.checkOutput = failedResults.map(r => `${r.target} has been null for ${Math.round(r.nullsForHowManySeconds / 60)} minutes.`).join(' ');
-			}
-		} catch(err) {
-			log.error({ event: `${logEventPrefix}_ERROR`, url: this.url }, err);
-			this.status = status.FAILED;
-			this.checkOutput = err.toString();
-		}
-	}
+            if (failedResults.length === 0) {
+                this.status = status.PASSED;
+                this.checkOutput =`${this.metric} has data`;
+            } else {
+                this.status = status.FAILED;
+                this.checkOutput = failedResults.map(r => `${r.target} has been null for ${Math.round(r.nullsForHowManySeconds / 60)} minutes.`).join(' ');
+            }
+        } catch(err) {
+            log.error({ event: `${logEventPrefix}_ERROR`, url: this.getUrl() }, err);
+            this.status = status.FAILED;
+            this.checkOutput = err.toString();
+        }
+    }
 }
 
 module.exports = GraphiteWorkingCheck;
+

--- a/test/fixtures/config/graphiteWorkingFixture.js
+++ b/test/fixtures/config/graphiteWorkingFixture.js
@@ -8,6 +8,21 @@ module.exports = {
 			metric: 'next.fastly.f8585BOxnGQDMbnkJoM1e.all.requests',
 			severity: 2,
 			businessImpact: 'loss of millions in pounds'
+		},
+		{
+			type: 'graphiteWorking',
+			name: 'test1',
+			metric: 'next.fastly.f8585BOxnGQDMbnkJoM1e.all.requests',
+			severity: 2,
+			businessImpact: 'loss of millions in pounds',
+			time : "-30minutes",
+			interval:10,
+			override:{
+				weekend : {
+					time : "-60minutes",
+					metric: "next.fastly.f8585BOxnGQDMbnkJoM1e.weekend.requests"
+				}
+			}
 		}
 	]
 };

--- a/test/graphiteworking.spec.js
+++ b/test/graphiteworking.spec.js
@@ -1,12 +1,12 @@
 'use strict';
 const expect = require('chai').expect;
 const sinon = require('sinon');
-const proxyquire = require('proxyquire').noCallThru().noPreserveCache();
+const proxyquire = require('proxyquire').noCallThru().noPreserveCache();	
 
 describe('Graphite Working Check', function(){
-
-	const fixture = require('./fixtures/config/graphiteWorkingFixture').checks[0];
-
+	const fixtures = require('./fixtures/config/graphiteWorkingFixture');
+	const fixtureBasic = fixtures.checks[0];
+	const fixtureWeekend = fixtures.checks[1];
 	let GraphiteWorkingCheck;
 	let check;
 	let mockFetch;
@@ -57,7 +57,7 @@ describe('Graphite Working Check', function(){
 		return new Promise(resolve => setTimeout(resolve, time));
 	}
 
-	function setup(response){
+	function setup(response,fixture = fixtureBasic){
 		mockFetch = sinon.stub().returns(Promise.resolve({
 			ok: true,
 			json: function(){
@@ -75,7 +75,7 @@ describe('Graphite Working Check', function(){
 		return waitFor(10).then(() => {
 			sinon.assert.called(mockFetch);
 			let url = mockFetch.lastCall.args[0];
-			expect(url).to.contain(fixture.metric);
+			expect(url).to.contain(fixtureBasic.metric);
 			expect(url).to.contain('format=json');
 		});
 	});
@@ -106,7 +106,36 @@ describe('Graphite Working Check', function(){
             expect(check.getStatus().checkOutput).to.equal('summarize(next.fastly.133g5BGAc00Hv4v8t0dMry.anzac.requests, "1h", "sum", true) has been null for Infinity minutes.');
         });
     });
+	
+	describe("Applying overrides", () => {
+	
+		it('Should override parameters while weekend',async () => {
+			setup(goodResponse,fixtureWeekend)
+			//mock to be weekend
+			check.isWeekend = sinon.stub().returns(() => true);
+			check.start();
+			await waitFor(10);
+			sinon.assert.called(check.isWeekend );
+			sinon.assert.called(mockFetch);
+			expect(check.getStatus().checkOutput).to.equal('next.fastly.f8585BOxnGQDMbnkJoM1e.weekend.requests has data');
+			expect(check.time).to.equal(fixtureWeekend.override.weekend.time);
+			expect(check.metric).to.equal(fixtureWeekend.override.weekend.metric)
+			expect(check.initialState.metric).to.equal(fixtureWeekend.metric);
+			expect(check.initialState.time).to.equal(fixtureWeekend.time)
+			expect(check.getStatus().ok).to.be.true;
+			check.isWeekend = sinon.stub().returns(() => false);
 
+			await waitFor(10);
+			sinon.assert.calledTwice(mockFetch);
+			sinon.assert.called(check.isWeekend );
+			expect(check.getStatus().checkOutput).to.equal('next.fastly.f8585BOxnGQDMbnkJoM1e.all.requests has data');
+			expect(check.time).to.equal(fixtureWeekend.time);
+			expect(check.metric).to.equal(fixtureWeekend.metric)
+			expect(check.initialState.metric).to.equal(fixtureWeekend.metric);
+			expect(check.initialState.time).to.equal(fixtureWeekend.time)
+			expect(check.getStatus().ok).to.be.true;
+		})
+	})
 	//todo get the graphite api key into the CI config - doesn't seem possible right now...
 	describe.skip('Integration', function(){
 


### PR DESCRIPTION
With this PR we add to graphiteWorking a new property which is "override" that will serve to override properties based in a certain situation.
In this PR we have implemented only the "weekend" situation , where the properties of the healthcheck will be overriden with the properties we pass inside this object.
As an example value for "override" property could be something like this.

```
override:{
		weekend : {
			time : "-60minutes",
			metric: "next.fastly.f8585BOxnGQDMbnkJoM1e.weekend.requests"
			}
		}
```

The reason of this change is that in certain situations like in weekends we have less number of items on certain metrics and we need to set a different threshold values.
[ticket](https://financialtimes.atlassian.net/jira/software/c/projects/CI/boards/1653?modal=detail&selectedIssue=CI-1738)
