### PR TITLE
Soften the logging

### DIFF
--- a/src/checks/graphiteThreshold.check.js
+++ b/src/checks/graphiteThreshold.check.js
@@ -55,7 +55,7 @@ class GraphiteThresholdCheck extends Check {
 				if(result.target && asPercentRegex.test(result.target) || result.target && divideSeriesRegex.test(result.target)){
 					const fetchCountPerTimeUnit = result.datapoints.map(item => Number(item[0]));
 					if(fetchCountPerTimeUnit.length !== 1){
-						logger.info({
+						logger.debug({
 							event: 'HEALTHCHECK_LENGTH_NOT_1',
 							datapoints: result.datapoints
 						});
@@ -80,7 +80,7 @@ class GraphiteThresholdCheck extends Check {
 					if (value[0] === null) {
 						// metric data is unavailable, we don't fail this threshold check if metric data is unavailable
 						// if you want a failing check for when metric data is unavailable, use graphiteWorking
-						logger.info({
+						logger.debug({
 							event: `${logEventPrefix}_NULL_DATA`,
 							url: this.sampleUrl,
 						});

--- a/src/checks/graphiteWorking.check.js
+++ b/src/checks/graphiteWorking.check.js
@@ -66,7 +66,7 @@ class GraphiteWorkingCheck extends Check {
 						}
 
 				const simplifiedResult = { target: result.target, nullsForHowManySeconds };
-				log.info({ event: `${logEventPrefix}_NULLS_FOR_HOW_LONG` }, simplifiedResult);
+				log.debug({ event: `${logEventPrefix}_NULLS_FOR_HOW_LONG` }, simplifiedResult);
 				return simplifiedResult;
 			});
 

--- a/test/graphiteThreshold.check.spec.js
+++ b/test/graphiteThreshold.check.spec.js
@@ -13,6 +13,7 @@ const mockLogger = {
 	default: {
 		error: function() {},
 		info: function() {},
+		debug: function() {},
 	}
 }
 


### PR DESCRIPTION
One of the reasons we have a log level of `warn` is because we traditionally over-logged with a level of `info`. I'm switching some of the info-level logs in our dependencies to `debug` so that you can opt in when debugging an app but we don't flood Splunk.