### PR TITLE
Remove moment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@dotcom-reliability-kit/logger": "^3.0.3",
         "aws-sdk": "^2.6.10",
         "fetchres": "^1.5.1",
-        "moment": "^2.29.4",
         "ms": "^2.0.0",
         "node-fetch": "^2.6.7"
       },
@@ -7684,14 +7683,6 @@
       "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
       "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
       "dev": true
-    },
-    "node_modules/moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -18569,11 +18560,6 @@
       "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
       "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
       "dev": true
-    },
-    "moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@dotcom-reliability-kit/logger": "^3.0.3",
     "aws-sdk": "^2.6.10",
     "fetchres": "^1.5.1",
-    "moment": "^2.29.4",
     "ms": "^2.0.0",
     "node-fetch": "^2.6.7"
   },

--- a/src/checks/cloudWatchThreshold.check.js
+++ b/src/checks/cloudWatchThreshold.check.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const AWS = require('aws-sdk');
-const moment = require('moment');
 const logger = require('@dotcom-reliability-kit/logger');
 const status = require('./status');
 const Check = require('./check');
@@ -32,11 +31,12 @@ class CloudWatchThresholdCheck extends Check {
 	generateParams() {
 		// use a larger window when gathering stats, because CloudWatch
 		// can take its sweet time with populating new datapoints.
-		let timeWindow = this.samplePeriod * 1.5;
-		const now = moment();
+		let timeWindowInMs = this.samplePeriod * 1.5 * 1000;
+		const now = new Date();
+		const startTime = new Date(now.getTime() - timeWindowInMs);
 		return {
 			EndTime: now.toISOString(),
-			StartTime: now.subtract(timeWindow, 'seconds').toISOString(),
+			StartTime: startTime.toISOString(),
 			MetricName: this.cloudWatchMetricName,
 			Namespace: this.cloudWatchNamespace,
 			Period: this.samplePeriod,

--- a/src/checks/fastlyKeyExpiration.check.js
+++ b/src/checks/fastlyKeyExpiration.check.js
@@ -84,7 +84,7 @@ class FastlyKeyExpirationCheck extends Check {
 		let date;
 		try {
 			date = new Date(stringDate);
-			dateIsValid = Number.isNaN(date.getDate());
+			dateIsValid = !Number.isNaN(date.getDate());
 		} catch (error) {
 			dateIsValid = false;
 		}
@@ -109,7 +109,7 @@ class FastlyKeyExpirationCheck extends Check {
 		switch (true) {
 			case expirationDate > limitDate:
 				return this.states.PASSED;
-			case expirationDate < now:
+			case expirationDate <= now:
 				return this.states.FAILED_URGENT_VALIDATION;
 			default:
 				return this.states.FAILED_VALIDATION;


### PR DESCRIPTION
Slight side-track, but oh well, here we are! We don't need Moment for these use-cases, and they're probably clear enough without needing any date manipulation/parsing libraries.

## Date addition / subtraction

We can add/subtract using regular date. The following code to subtract seconds is equivalent:

```js
function runMoment(samplePeriod) {
  const timeWindow = samplePeriod * 1.5;
  const now = moment();
  const startTime = now.subtract(timeWindow, 'seconds');
  return startTime.toISOString();
}

function runDate(samplePeriod) {
  const timeWindowInMs = (samplePeriod * 1.5) * 1000;
  const now = new Date();
  const startTime = new Date(now.getTime() - timeWindowInMs);
  return startTime.toISOString();
}

console.log("moment", runMoment(60 * 5));
console.log("js", runDate(60 * 5));
```

The following code to add two weeks to a date is equivalent:

```js
function runMoment() {
  const now = moment();
  const limitDate = moment().add(2, 'weeks');
  return limitDate.toISOString();
}

function runDate() {
  const now = new Date();
  const limitDate = new Date();
  limitDate.setDate(now.getDate() + (2 * 7));
  return limitDate.toISOString();
}

console.log("moment", runMoment());
console.log("js", runDate());
```

## Date comparison

Dates can be compared with regular operators:

```js
console.log(new Date('2023-01-01') > new Date('2024-01-01'));
```

## Date parsing

Date parsing is generally fine too especially in ISO format, we can do a little bit of extra validation but tbh I don't think it's needed - we can just trust the date format that the Fastly API returns (it's the only place this date can come from). These are the same:

```js
console.log(moment("2024-01-26T10:00:00Z", 'YYYY-MM-DDTHH:mm:ssZ').toISOString());
console.log(new Date("2024-01-26T10:00:00Z").toISOString());
```
