### PR TITLE
Properly escape periods in hostname regexp

### DIFF
--- a/test/graphiteSpike.check.spec.js
+++ b/test/graphiteSpike.check.spec.js
@@ -45,7 +45,7 @@ describe('Graphite Spike Check', function () {
 			check.start();
 			setTimeout(() => {
 				expect(mockFetch.firstCall.args[0]).to.match(
-					/^https:\/\/graphitev2-api.ft.com\/render\/\?/
+					/^https:\/\/graphitev2-api\.ft\.com\/render\/\?/
 				);
 				done();
 			});


### PR DESCRIPTION
See https://github.com/Financial-Times/n-health/security/code-scanning/1