### PR TITLE
Remove Chai

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "@dotcom-tool-kit/mocha": "^4.0.1",
         "@dotcom-tool-kit/prettier": "^4.0.1",
         "@financial-times/eslint-config-next": "^7.1.0",
-        "chai": "^4.3.6",
         "dotcom-tool-kit": "^4.0.1",
         "mocha": "^10.0.0",
         "proxyquire": "^2.1.3",
@@ -2826,15 +2825,6 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
-    "node_modules/assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -3034,24 +3024,6 @@
       ],
       "peer": true
     },
-    "node_modules/chai": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
-      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
-      "dev": true,
-      "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
-        "get-func-name": "^2.0.0",
-        "loupe": "^2.3.1",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.0.5"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -3073,15 +3045,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/chokidar": {
@@ -3379,18 +3342,6 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
       "dev": true
-    },
-    "node_modules/deep-eql": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-      "dev": true,
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -4153,15 +4104,6 @@
       "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/get-own-enumerable-property-symbols": {
@@ -5312,15 +5254,6 @@
         "node": ">= 12.0.0"
       }
     },
-    "node_modules/loupe": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
-      "integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
-      "dev": true,
-      "dependencies": {
-        "get-func-name": "^2.0.0"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -6359,15 +6292,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/picocolors": {
@@ -10128,12 +10052,6 @@
         "readable-stream": "^3.6.0"
       }
     },
-    "assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true
-    },
     "astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -10261,21 +10179,6 @@
       "dev": true,
       "peer": true
     },
-    "chai": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
-      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
-      "dev": true,
-      "requires": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
-        "get-func-name": "^2.0.0",
-        "loupe": "^2.3.1",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.0.5"
-      }
-    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -10294,12 +10197,6 @@
           "dev": true
         }
       }
-    },
-    "check-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
-      "dev": true
     },
     "chokidar": {
       "version": "3.5.3",
@@ -10538,15 +10435,6 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
       "dev": true
-    },
-    "deep-eql": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-      "dev": true,
-      "requires": {
-        "type-detect": "^4.0.0"
-      }
     },
     "deep-is": {
       "version": "0.1.4",
@@ -11131,12 +11019,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
-    },
-    "get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
       "dev": true
     },
     "get-own-enumerable-property-symbols": {
@@ -12002,15 +11884,6 @@
         "triple-beam": "^1.3.0"
       }
     },
-    "loupe": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
-      "integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
-      "dev": true,
-      "requires": {
-        "get-func-name": "^2.0.0"
-      }
-    },
     "lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -12809,12 +12682,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true
-    },
-    "pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true
     },
     "picocolors": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@dotcom-tool-kit/mocha": "^4.0.1",
     "@dotcom-tool-kit/prettier": "^4.0.1",
     "@financial-times/eslint-config-next": "^7.1.0",
-    "chai": "^4.3.6",
     "dotcom-tool-kit": "^4.0.1",
     "mocha": "^10.0.0",
     "proxyquire": "^2.1.3",

--- a/test/aggregate.check.spec.js
+++ b/test/aggregate.check.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const expect = require('chai').expect;
+const assert = require('node:assert/strict');
 const config = require('./fixtures/config/aggregate').checks[2];
 const AggregateCheck = require('../src/checks/').aggregate;
 
@@ -34,7 +34,7 @@ describe('Aggregate Check', function () {
 			MockHealthChecks.checks[1].ok = true;
 			check.start();
 			setTimeout(function () {
-				expect(check.getStatus().ok).to.be.true;
+				assert.equal(check.getStatus().ok, true);
 				done();
 			});
 		});
@@ -44,7 +44,7 @@ describe('Aggregate Check', function () {
 			MockHealthChecks.checks[1].ok = false;
 			check.start();
 			setTimeout(function () {
-				expect(check.getStatus().ok).to.be.false;
+				assert.equal(check.getStatus().ok, false);
 				done();
 			});
 		});

--- a/test/cloudWatchAlarm.check.spec.js
+++ b/test/cloudWatchAlarm.check.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const expect = require('chai').expect;
+const assert = require('node:assert/strict');
 const configFixture = require('./fixtures/config/cloudWatchAlarmFixture')
 	.checks[0];
 const failedFixture = require('./fixtures/cloudWatchAlarmFailedResponse');
@@ -43,21 +43,20 @@ describe('CloudWatch Alarm Check', () => {
 		check.start();
 		await waitFor(10);
 		//
-		expect(cloudWatchSdkMock.CloudWatchClient.calledOnce).to.be.true;
-		expect(cloudWatchSdkMock.CloudWatchClient.calledWithNew()).to.be.true;
-		expect(cloudWatchSdkMock.DescribeAlarmsCommand.calledOnce).to.be.true;
-		expect(cloudWatchSdkMock.DescribeAlarmsCommand.calledWithNew()).to.be.true;
-		expect(cloudWatchClientMock.send.calledOnce).to.be.true;
+		assert.equal(cloudWatchSdkMock.CloudWatchClient.calledOnce, true);
+		assert.equal(cloudWatchSdkMock.CloudWatchClient.calledWithNew(), true);
+		assert.equal(cloudWatchSdkMock.DescribeAlarmsCommand.calledOnce, true);
+		assert.equal(cloudWatchSdkMock.DescribeAlarmsCommand.calledWithNew(), true);
+		assert.equal(cloudWatchClientMock.send.calledOnce, true);
 
 		const sendArgs = cloudWatchClientMock.send.lastCall.args[0];
-		expect(sendArgs).to.deep.equal(cloudWatchCommandMock);
+		assert.deepEqual(sendArgs, cloudWatchCommandMock);
 
 		const commandArgs =
 			cloudWatchSdkMock.DescribeAlarmsCommand.lastCall.args[0];
-		expect(commandArgs).to.have.property('AlarmNames');
-		expect(commandArgs.AlarmNames).to.be.an('Array');
-		expect(commandArgs.AlarmNames[0]).to.be.an('String');
-		expect(commandArgs.AlarmNames[0]).to.equal('test');
+		assert.ok(commandArgs.AlarmNames);
+		assert.ok(Array.isArray(commandArgs.AlarmNames));
+		assert.equal(commandArgs.AlarmNames[0], 'test');
 	});
 
 	it('Should pass if the current state of the given alarm is OK', async () => {
@@ -65,7 +64,7 @@ describe('CloudWatch Alarm Check', () => {
 		check = new Check(configFixture);
 		check.start();
 		await waitFor(10);
-		expect(check.getStatus().ok).to.be.true;
+		assert.equal(check.getStatus().ok, true);
 	});
 
 	it('Should fail if the current state of the given alarm is ALARM', async () => {
@@ -73,7 +72,7 @@ describe('CloudWatch Alarm Check', () => {
 		check = new Check(configFixture);
 		check.start();
 		await waitFor(10);
-		expect(check.getStatus().ok).to.be.false;
+		assert.equal(check.getStatus().ok, false);
 	});
 
 	it('Should fail if there is no data', async () => {
@@ -81,6 +80,6 @@ describe('CloudWatch Alarm Check', () => {
 		check = new Check(configFixture);
 		check.start();
 		await waitFor(10);
-		expect(check.getStatus().ok).to.be.false;
+		assert.equal(check.getStatus().ok, false);
 	});
 });

--- a/test/cloudWatchThreshold.check.spec.js
+++ b/test/cloudWatchThreshold.check.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const expect = require('chai').expect;
+const assert = require('node:assert/strict');
 const configFixture = require('./fixtures/config/cloudWatchThresholdFixture');
 const proxyquire = require('proxyquire').noCallThru().noPreserveCache();
 const sinon = require('sinon');
@@ -55,7 +55,7 @@ describe('CloudWatch Threshold Check', () => {
 		);
 		check.start();
 		setTimeout(() => {
-			expect(check.getStatus().ok).to.be.true;
+			assert.equal(check.getStatus().ok, true);
 			done();
 		});
 	});
@@ -69,7 +69,7 @@ describe('CloudWatch Threshold Check', () => {
 		);
 		check.start();
 		setTimeout(() => {
-			expect(check.getStatus().ok).to.be.false;
+			assert.equal(check.getStatus().ok, false);
 			done();
 		});
 	});
@@ -84,7 +84,7 @@ describe('CloudWatch Threshold Check', () => {
 		);
 		check.start();
 		setTimeout(() => {
-			expect(check.getStatus().ok).to.be.true;
+			assert.equal(check.getStatus().ok, true);
 			done();
 		});
 	});
@@ -99,7 +99,7 @@ describe('CloudWatch Threshold Check', () => {
 		);
 		check.start();
 		setTimeout(() => {
-			expect(check.getStatus().ok).to.be.false;
+			assert.equal(check.getStatus().ok, false);
 			done();
 		});
 	});
@@ -114,8 +114,7 @@ describe('CloudWatch Threshold Check', () => {
 		check.start();
 		setTimeout(() => {
 			let args = cloudWatchSdkMock.GetMetricStatisticsCommand.lastCall.args[0];
-			expect(args).to.have.property('Period');
-			expect(args.Period).to.equal(600);
+			assert.equal(args.Period, 600);
 			done();
 		});
 	});
@@ -130,10 +129,8 @@ describe('CloudWatch Threshold Check', () => {
 		check.start();
 		setTimeout(() => {
 			let args = cloudWatchSdkMock.GetMetricStatisticsCommand.lastCall.args[0];
-			expect(args).to.have.property('StartTime');
-			expect(args.StartTime).to.be.an.instanceof(Date);
-			expect(args).to.have.property('EndTime');
-			expect(args.EndTime).to.be.an.instanceof(Date);
+			assert.ok(args.StartTime instanceof Date);
+			assert.ok(args.EndTime instanceof Date);
 			done();
 		});
 	});
@@ -153,10 +150,7 @@ describe('CloudWatch Threshold Check', () => {
 		check.start();
 		setTimeout(() => {
 			let args = cloudWatchSdkMock.GetMetricStatisticsCommand.lastCall.args[0];
-			expect(args).to.have.property('Dimensions');
-			expect(args.Dimensions).to.have.length(1);
-			expect(args.Dimensions[0].Name).to.equal('foo');
-			expect(args.Dimensions[0].Value).to.equal('bar');
+			assert.deepEqual(args.Dimensions, [{ Name: 'foo', Value: 'bar' }]);
 			done();
 		});
 	});
@@ -166,7 +160,7 @@ describe('CloudWatch Threshold Check', () => {
 		check = new Check(getCheckConfig());
 		check.start();
 		setTimeout(() => {
-			expect(check.getStatus().checkOutput).to.match(/Current value: [\d.]+/);
+			assert.match(check.getStatus().checkOutput, /Current value: [\d.]+/);
 			done();
 		});
 	});
@@ -176,7 +170,7 @@ describe('CloudWatch Threshold Check', () => {
 		check = new Check(getCheckConfig());
 		check.start();
 		setTimeout(() => {
-			expect(check.getStatus().checkOutput).to.match(/Current value: 99$/);
+			assert.match(check.getStatus().checkOutput, /Current value: 99$/);
 			done();
 		});
 	});
@@ -192,7 +186,7 @@ describe('CloudWatch Threshold Check', () => {
 		setTimeout(() => {
 			let args = cloudWatchSdkMock.GetMetricStatisticsCommand.lastCall.args[0];
 			let timeWindow = new Date(args.EndTime) - new Date(args.StartTime);
-			expect(timeWindow).to.equal(90 * 1000);
+			assert.equal(timeWindow, 90 * 1000);
 			done();
 		});
 	});
@@ -208,7 +202,7 @@ describe('CloudWatch Threshold Check', () => {
 		setTimeout(() => {
 			let args = cloudWatchSdkMock.GetMetricStatisticsCommand.lastCall.args[0];
 			let timeWindow = new Date(args.EndTime) - new Date(args.StartTime);
-			expect(timeWindow).to.equal(450 * 1000);
+			assert.equal(timeWindow, 450 * 1000);
 			done();
 		});
 	});

--- a/test/fastlyKeyExpiration.check.spec.js
+++ b/test/fastlyKeyExpiration.check.spec.js
@@ -1,5 +1,5 @@
 const sinon = require('sinon');
-const { expect } = require('chai');
+const assert = require('node:assert/strict');
 const proxyquire = require('proxyquire').noCallThru().noPreserveCache();
 const logger = require('@dotcom-reliability-kit/logger');
 const FastlyCheck = require('../src/checks/fastlyKeyExpiration.check');
@@ -53,21 +53,19 @@ describe('Fastly Key Expiration Check', () => {
 				severity: 2
 			}
 		};
-		expect(fastlyKeyExpirationCheck.states).to.be.deep.equal(initialStates);
+		assert.deepEqual(fastlyKeyExpirationCheck.states, initialStates);
 		fastlyKeyExpirationCheck.severity = 1;
-		expect(fastlyKeyExpirationCheck.states).to.be.deep.equal(initialStates);
+		assert.deepEqual(fastlyKeyExpirationCheck.states, initialStates);
 	});
 
 	it('returns ok=false if fastly key check has not yet run', async () => {
 		sinon.stub(FastlyCheck.prototype, 'tick');
 		const fastlyCheck = new FastlyCheck(defaultOptions);
 		const result = fastlyCheck.getStatus();
-		expect(result.ok).to.be.false;
+		assert.equal(result.ok, false);
 		// Default error message for ERRORED states in parent function Check
-		expect(result.checkOutput).to.be.equal(
-			fastlyCheck.states.PENDING.checkOutput
-		);
-		expect(result.severity).to.be.equal(fastlyCheck.states.PENDING.severity);
+		assert.equal(result.checkOutput, fastlyCheck.states.PENDING.checkOutput);
+		assert.equal(result.severity, fastlyCheck.states.PENDING.severity);
 	});
 	it('returns ok=false if key check failed to fetch data & logs errors', async () => {
 		// Arrange
@@ -80,11 +78,11 @@ describe('Fastly Key Expiration Check', () => {
 		// Act
 		const result = fastlyCheck.getStatus();
 		// Assert
-		expect(result.ok).to.be.false;
+		assert.equal(result.ok, false);
 		// Default error message for ERRORED states in parent function Check
-		expect(result.checkOutput).to.be.equal('Healthcheck failed to execute');
-		expect(result.severity).to.be.equal(fastlyCheck.states.ERRORED.severity);
-		expect(logger.error.args).to.be.deep.equal([
+		assert.equal(result.checkOutput, 'Healthcheck failed to execute');
+		assert.equal(result.severity, fastlyCheck.states.ERRORED.severity);
+		assert.deepEqual(logger.error.args, [
 			['Failed to get Fastly key metadata', 'Timeout']
 		]);
 	});
@@ -104,11 +102,13 @@ describe('Fastly Key Expiration Check', () => {
 		// Act
 		const result = fastlyCheck.getStatus();
 		// Assert
-		expect(result.ok).to.be.false;
-		expect(result.checkOutput).to.be.equal(
+		assert.equal(result.ok, false);
+		assert.equal(
+			result.checkOutput,
 			fastlyCheck.states.FAILED_URGENT_VALIDATION.checkOutput
 		);
-		expect(result.severity).to.be.equal(
+		assert.equal(
+			result.severity,
 			fastlyCheck.states.FAILED_URGENT_VALIDATION.severity
 		);
 	});
@@ -128,11 +128,13 @@ describe('Fastly Key Expiration Check', () => {
 		// Act
 		const result = fastlyCheck.getStatus();
 		// Assert
-		expect(result.ok).to.be.false;
-		expect(result.checkOutput).to.be.equal(
+		assert.equal(result.ok, false);
+		assert.equal(
+			result.checkOutput,
 			fastlyCheck.states.FAILED_VALIDATION.checkOutput
 		);
-		expect(result.severity).to.be.equal(
+		assert.equal(
+			result.severity,
 			fastlyCheck.states.FAILED_VALIDATION.severity
 		);
 	});
@@ -152,11 +154,9 @@ describe('Fastly Key Expiration Check', () => {
 		// Act
 		const result = fastlyCheck.getStatus();
 		// Assert
-		expect(result.ok).to.be.true;
-		expect(result.checkOutput).to.be.equal(
-			fastlyCheck.states.PASSED.checkOutput
-		);
-		expect(result.severity).to.be.equal(fastlyCheck.states.PASSED.severity);
+		assert.equal(result.ok, true);
+		assert.equal(result.checkOutput, fastlyCheck.states.PASSED.checkOutput);
+		assert.equal(result.severity, fastlyCheck.states.PASSED.severity);
 	});
 	it('returns ok=false if expiration date is not valid & logs warning', async () => {
 		// Arrange
@@ -168,14 +168,13 @@ describe('Fastly Key Expiration Check', () => {
 		// Act
 		const result = fastlyCheck.getStatus();
 		// Assert
-		expect(result.ok).to.be.false;
-		expect(result.checkOutput).to.be.equal(
+		assert.equal(result.ok, false);
+		assert.equal(
+			result.checkOutput,
 			fastlyCheck.states.FAILED_DATE.checkOutput
 		);
-		expect(result.severity).to.be.equal(
-			fastlyCheck.states.FAILED_DATE.severity
-		);
-		expect(logger.warn.args).to.be.deep.equal([
+		assert.equal(result.severity, fastlyCheck.states.FAILED_DATE.severity);
+		assert.deepEqual(logger.warn.args, [
 			['Invalid Fastly Key expiration date aaaa']
 		]);
 	});

--- a/test/healthchecks.spec.js
+++ b/test/healthchecks.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const expect = require('chai').expect;
+const assert = require('node:assert/strict');
 const JsonCheck = require('../src/checks/').json;
 
 describe('Healthchecks', function () {
@@ -25,19 +25,19 @@ describe('Healthchecks', function () {
 
 	it('Should be able to read in the config object', function () {
 		const props = ['name', 'description'];
-		expect(extract(healthchecks, props)).to.deep.equal(extract(fixture, props));
+		assert.deepEqual(extract(healthchecks, props), extract(fixture, props));
 	});
 
 	it('Should create new checks as described in the config', function () {
-		expect(healthchecks.checks[0]).to.be.an.instanceOf(JsonCheck);
+		assert.ok(healthchecks.checks[0] instanceof JsonCheck);
 	});
 
 	it('Should report its status correctly', function () {
 		const status = healthchecks.getStatus();
-		expect(status.name).to.equal(fixture.name);
-		expect(status.description).to.equal(fixture.description);
-		expect(status.checks.length).to.equal(1);
-		expect(status.checks[0].name).to.equal(fixture.checks[0].name);
-		expect(status.checks[0].panicGuide).to.equal(fixture.checks[0].panicGuide);
+		assert.equal(status.name, fixture.name);
+		assert.equal(status.description, fixture.description);
+		assert.equal(status.checks.length, 1);
+		assert.equal(status.checks[0].name, fixture.checks[0].name);
+		assert.equal(status.checks[0].panicGuide, fixture.checks[0].panicGuide);
 	});
 });

--- a/test/json.check.spec.js
+++ b/test/json.check.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const expect = require('chai').expect;
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const config = require('./fixtures/config/jsonCheckFixture').checks[0];
 const proxyquire = require('proxyquire').noCallThru().noPreserveCache();
@@ -43,7 +43,7 @@ describe('JSON Checker', function () {
 		check.start();
 		setTimeout(function () {
 			sinon.assert.calledWith(mockFetch, config.url, config.fetchOptions);
-			expect(check.getStatus().ok).to.be.true;
+			assert.equal(check.getStatus().ok, true);
 			done();
 		});
 	});
@@ -53,7 +53,7 @@ describe('JSON Checker', function () {
 		check.start();
 		setTimeout(function () {
 			sinon.assert.calledWith(mockFetch, config.url, config.fetchOptions);
-			expect(check.getStatus().ok).to.be.false;
+			assert.equal(check.getStatus().ok, false);
 			done();
 		});
 	});

--- a/test/responseCompare.check.spec.js
+++ b/test/responseCompare.check.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const expect = require('chai').expect;
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru().noPreserveCache();
 const config = require('./fixtures/config/responseCompareFixture').checks;
@@ -32,7 +32,7 @@ describe('Response Compare Check', function () {
 			check.start();
 			setImmediate(function () {
 				sinon.assert.called(mockFetch);
-				expect(check.getStatus().ok).to.be.true;
+				assert.equal(check.getStatus().ok, true);
 				check.stop();
 				done();
 			});
@@ -43,7 +43,7 @@ describe('Response Compare Check', function () {
 			check.start();
 			setImmediate(function () {
 				sinon.assert.called(mockFetch);
-				expect(check.getStatus().ok).to.be.false;
+				assert.equal(check.getStatus().ok, false);
 				check.stop();
 				done();
 			});
@@ -54,7 +54,7 @@ describe('Response Compare Check', function () {
 			check.start();
 			setImmediate(function () {
 				sinon.assert.called(mockFetch);
-				expect(check.getStatus().ok).to.be.true;
+				assert.equal(check.getStatus().ok, true);
 				check.stop();
 				done();
 			});
@@ -65,7 +65,7 @@ describe('Response Compare Check', function () {
 			check.start();
 			setImmediate(function () {
 				sinon.assert.called(mockFetch);
-				expect(check.getStatus().ok).to.be.false;
+				assert.equal(check.getStatus().ok, false);
 				check.stop();
 				done();
 			});

--- a/test/startup.spec.js
+++ b/test/startup.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const expect = require('chai').expect;
+const assert = require('node:assert/strict');
 const path = require('path');
 const HealthChecks = require('../src/healthchecks');
 const startup = require('../src/startup');
@@ -8,8 +8,7 @@ const startup = require('../src/startup');
 describe('Startup', function () {
 	it('Should read in the config dir and create new healthcheck objects', function () {
 		const result = startup(path.resolve(__dirname, 'fixtures/config/'));
-		expect(result.get('sourcemap')).not.to.exist;
-		expect(result.get('paywall')).to.exist;
-		expect(result.get('paywall')).to.be.an.instanceOf(HealthChecks);
+		assert.equal(result.get('sourcemap'), undefined);
+		assert.ok(result.get('paywall') instanceof HealthChecks);
 	});
 });

--- a/test/string.check.spec.js
+++ b/test/string.check.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const expect = require('chai').expect;
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const config = require('./fixtures/config/stringCheckFixture').checks[0];
 const proxyquire = require('proxyquire').noCallThru().noPreserveCache();
@@ -29,7 +29,7 @@ describe('String Checker', function () {
 		setTimeout(function () {
 			sinon.assert.calledWith(mockFetch, config.url);
 			sinon.assert.calledWith(mockFetch, config.url, config.fetchOptions);
-			expect(check.getStatus().ok).to.be.true;
+			assert.equal(check.getStatus().ok, true);
 			done();
 		});
 	});
@@ -40,7 +40,7 @@ describe('String Checker', function () {
 		setTimeout(function () {
 			sinon.assert.calledWith(mockFetch, config.url);
 			sinon.assert.calledWith(mockFetch, config.url, config.fetchOptions);
-			expect(check.getStatus().ok).to.be.false;
+			assert.equal(check.getStatus().ok, false);
 			done();
 		});
 	});


### PR DESCRIPTION
[Chai v5 is ESM-only](https://www.chaijs.com/releases/#v5.0.0) which would be a really big migration. We're not doing any complicated assertions in the tests here so I think it makes sense to just switch to the built-in [`assert`](https://nodejs.org/api/assert.html) module. We get to drop a dependency (just under 1MB) and I think assert is easier to understand anyway.